### PR TITLE
Add 56 interfaces from public repo

### DIFF
--- a/dtmi/advantech/devicedetailedinformation-1.json
+++ b/dtmi/advantech/devicedetailedinformation-1.json
@@ -1,0 +1,44 @@
+{
+  "@id": "dtmi:Advantech:DeviceDetailedInformation;1",
+  "@type": "Interface",
+  "displayName": "Device Detailed Information",
+  "@context": "dtmi:dtdl:context;2",
+  "contents": [
+    {
+      "@type": "Property",
+      "displayName": "BIOS Version",
+      "name": "BiosVersion",
+      "schema": "string"
+    },
+    {
+      "@type": "Property",
+      "displayName": "EC Firmware",
+      "name": "ECFirmware",
+      "schema": "string"
+    },
+    {
+      "@type": "Property",
+      "displayName": "Driver Version",
+      "name": "DriverVersion",
+      "schema": "string"
+    },
+    {
+      "@type": "Property",
+      "displayName": "Library Version",
+      "name": "LibraryVersion",
+      "schema": "string"
+    },
+    {
+      "@type": "Property",
+      "displayName": "Firmware Version",
+      "name": "FirmwareVersion",
+      "schema": "string"
+    },
+    {
+      "@type": "Property",
+      "displayName": "Last Connected At",
+      "name": "LastConnectedAt",
+      "schema": "dateTime"
+    }
+  ]
+}

--- a/dtmi/advantech/eis_d150-1.json
+++ b/dtmi/advantech/eis_d150-1.json
@@ -1,0 +1,38 @@
+{
+  "@id": "dtmi:Advantech:EIS_D150;1",
+  "@type": "Interface",
+  "displayName": "EIS-D150",
+  "@context": "dtmi:dtdl:context;2",
+  "contents": [
+    {
+      "@type": "Component",
+      "name": "Device_Detailed_Information",
+      "schema": "dtmi:Advantech:DeviceDetailedInformation;1"
+    },
+    {
+      "@type": "Component",
+      "name": "Sensors_Information",
+      "schema": "dtmi:Advantech:SensorsInformation;2"
+    },
+    {
+      "@type": "Component",
+      "name": "deviceInfo",
+      "schema": "dtmi:azure:DeviceManagement:DeviceInformation;1"
+    },
+    {
+      "@type": "Component",
+      "name": "GPIO",
+      "schema": "dtmi:Advantech:GPIO;1"
+    },
+    {
+      "@type": "Component",
+      "name": "VGA",
+      "schema": "dtmi:Advantech:VGA;1"
+    },
+    {
+      "@type": "Component",
+      "name": "SDRAM",
+      "schema": "dtmi:Advantech:SDRAM;1"
+    }
+  ]
+}

--- a/dtmi/advantech/eis_d210-1.json
+++ b/dtmi/advantech/eis_d210-1.json
@@ -1,0 +1,38 @@
+{
+  "@id": "dtmi:Advantech:EIS_D210;1",
+  "@type": "Interface",
+  "displayName": "EIS-D210",
+  "@context": "dtmi:dtdl:context;2",
+  "contents": [
+    {
+      "@type": "Component",
+      "name": "Device_Detailed_Information",
+      "schema": "dtmi:Advantech:DeviceDetailedInformation;1"
+    },
+    {
+      "@type": "Component",
+      "name": "Sensors_Information",
+      "schema": "dtmi:Advantech:SensorsInformation;2"
+    },
+    {
+      "@type": "Component",
+      "name": "deviceInfo",
+      "schema": "dtmi:azure:DeviceManagement:DeviceInformation;1"
+    },
+    {
+      "@type": "Component",
+      "name": "GPIO",
+      "schema": "dtmi:Advantech:GPIO;1"
+    },
+    {
+      "@type": "Component",
+      "name": "VGA",
+      "schema": "dtmi:Advantech:VGA;1"
+    },
+    {
+      "@type": "Component",
+      "name": "SDRAM",
+      "schema": "dtmi:Advantech:SDRAM;1"
+    }
+  ]
+}

--- a/dtmi/advantech/epc_u2117-1.json
+++ b/dtmi/advantech/epc_u2117-1.json
@@ -1,0 +1,164 @@
+{
+  "@id": "dtmi:Advantech:EPC_U2117;1",
+  "@type": "Interface",
+  "displayName": "EPC-U2117",
+  "@context": "dtmi:dtdl:context;2",
+  "contents": [
+    {
+      "@type": "Property",
+      "displayName": "BIOS Version",
+      "name": "BiosVersion",
+      "schema": "string"
+    },
+    {
+      "@type": "Property",
+      "displayName": "EC Firmware",
+      "name": "ECFirmware",
+      "schema": "string"
+    },
+    {
+      "@type": "Property",
+      "displayName": "Driver Version",
+      "name": "DriverVersion",
+      "schema": "string"
+    },
+    {
+      "@type": "Property",
+      "displayName": "Library Version",
+      "name": "LibraryVersion",
+      "schema": "string"
+    },
+    {
+      "@type": "Property",
+      "displayName": "Firmware Version",
+      "name": "FirmwareVersion",
+      "schema": "string"
+    },
+    {
+      "@type": "Property",
+      "displayName": "Last Connected At",
+      "name": "LastConnectedAt",
+      "schema": "dateTime"
+    },
+    {
+      "@type": "Telemetry",
+      "displayName": "Voltage Vcore",
+      "name": "vvcore",
+      "schema": "double"
+    },
+    {
+      "@type": "Telemetry",
+      "displayName": "Voltage Vcore2",
+      "name": "vvcore2",
+      "schema": "double"
+    },
+    {
+      "@type": "Telemetry",
+      "displayName": "Voltage 2.5V",
+      "name": "v25v",
+      "schema": "double"
+    },
+    {
+      "@type": "Telemetry",
+      "displayName": "Voltage 3.3V",
+      "name": "v33v",
+      "schema": "double"
+    },
+    {
+      "@type": "Telemetry",
+      "displayName": "Voltage 5V",
+      "name": "v5v",
+      "schema": "double"
+    },
+    {
+      "@type": "Telemetry",
+      "displayName": "Voltage 12V",
+      "name": "v12v",
+      "schema": "double"
+    },
+    {
+      "@type": "Telemetry",
+      "displayName": "Voltage 5V Standby",
+      "name": "v5vstandby",
+      "schema": "double"
+    },
+    {
+      "@type": "Telemetry",
+      "displayName": "Voltage 3V Standby",
+      "name": "v3vstandby",
+      "schema": "double"
+    },
+    {
+      "@type": "Telemetry",
+      "displayName": "Voltage CMOS Battery",
+      "name": "vcmosbattery",
+      "schema": "double"
+    },
+    {
+      "@type": "Telemetry",
+      "displayName": "Voltage -5v",
+      "name": "v5nv",
+      "schema": "double"
+    },
+    {
+      "@type": "Telemetry",
+      "displayName": "Voltage -12v",
+      "name": "v12nv",
+      "schema": "double"
+    },
+    {
+      "@type": "Telemetry",
+      "displayName": "DIMM voltage",
+      "name": "vvtt",
+      "schema": "double"
+    },
+    {
+      "@type": "Telemetry",
+      "displayName": "Voltage 24v",
+      "name": "v24v",
+      "schema": "double"
+    },
+    {
+      "@type": "Telemetry",
+      "displayName": "Temperature CPU",
+      "name": "tcpu",
+      "schema": "double"
+    },
+    {
+      "@type": "Telemetry",
+      "displayName": "Temperature Chipset",
+      "name": "tchipset",
+      "schema": "double"
+    },
+    {
+      "@type": "Telemetry",
+      "displayName": "Temperature System",
+      "name": "tsystem",
+      "schema": "double"
+    },
+    {
+      "@type": "Telemetry",
+      "displayName": "Temperature CPU2",
+      "name": "tcpu2",
+      "schema": "double"
+    },
+    {
+      "@type": "Telemetry",
+      "displayName": "Fan CPU",
+      "name": "fcpu",
+      "schema": "double"
+    },
+    {
+      "@type": "Telemetry",
+      "displayName": "Fan System",
+      "name": "fsystem",
+      "schema": "double"
+    },
+    {
+      "@type": "Telemetry",
+      "displayName": "Fan CPU2",
+      "name": "fcpu2",
+      "schema": "double"
+    }
+  ]
+}

--- a/dtmi/advantech/epc_u2117-2.json
+++ b/dtmi/advantech/epc_u2117-2.json
@@ -1,0 +1,38 @@
+{
+  "@id": "dtmi:Advantech:EPC_U2117;2",
+  "@type": "Interface",
+  "displayName": "EPC-U2117",
+  "@context": "dtmi:dtdl:context;2",
+  "contents": [
+    {
+      "@type": "Component",
+      "name": "Device_Detailed_Information",
+      "schema": "dtmi:Advantech:DeviceDetailedInformation;1"
+    },
+    {
+      "@type": "Component",
+      "name": "Sensors_Information",
+      "schema": "dtmi:Advantech:SensorsInformation;2"
+    },
+    {
+      "@type": "Component",
+      "name": "deviceInfo",
+      "schema": "dtmi:azure:DeviceManagement:DeviceInformation;1"
+    },
+    {
+      "@type": "Component",
+      "name": "GPIO",
+      "schema": "dtmi:Advantech:GPIO;1"
+    },
+    {
+      "@type": "Component",
+      "name": "VGA",
+      "schema": "dtmi:Advantech:VGA;1"
+    },
+    {
+      "@type": "Component",
+      "name": "SDRAM",
+      "schema": "dtmi:Advantech:SDRAM;1"
+    }
+  ]
+}

--- a/dtmi/advantech/gpio-1.json
+++ b/dtmi/advantech/gpio-1.json
@@ -1,0 +1,68 @@
+{
+  "@id": "dtmi:Advantech:GPIO;1",
+  "@type": "Interface",
+  "displayName": "GPIO",
+  "@context": "dtmi:dtdl:context;2",
+  "contents": [
+    {
+      "@type": "Command",
+      "name": "SET_PIN",
+      "request": {
+        "name": "PIN",
+        "schema": "integer"
+      },
+      "response": {
+        "name": "PIN",
+        "schema": "integer"
+      }
+    },
+    {
+      "@type": "Command",
+      "name": "GET_PIN",
+      "response": {
+        "name": "PIN",
+        "schema": "integer"
+      }
+    },
+    {
+      "@type": "Command",
+      "name": "SET_VALUE",
+      "request": {
+        "name": "VALUE",
+        "schema": "integer"
+      },
+      "response": {
+        "name": "VALUE",
+        "schema": "integer"
+      }
+    },
+    {
+      "@type": "Command",
+      "name": "GET_VALUE",
+      "response": {
+        "name": "VALUE",
+        "schema": "integer"
+      }
+    },
+    {
+      "@type": "Command",
+      "name": "SET_DIRECTION",
+      "request": {
+        "name": "VALUE",
+        "schema": "integer"
+      },
+      "response": {
+        "name": "VALUE",
+        "schema": "integer"
+      }
+    },
+    {
+      "@type": "Command",
+      "name": "GET_DIRECTION",
+      "response": {
+        "name": "VALUE",
+        "schema": "integer"
+      }
+    }
+  ]
+}

--- a/dtmi/advantech/mic_77q-1.json
+++ b/dtmi/advantech/mic_77q-1.json
@@ -1,0 +1,38 @@
+{
+  "@id": "dtmi:Advantech:MIC_77Q;1",
+  "@type": "Interface",
+  "displayName": "MIC-77Q",
+  "@context": "dtmi:dtdl:context;2",
+  "contents": [
+    {
+      "@type": "Component",
+      "name": "Device_Detailed_Information",
+      "schema": "dtmi:Advantech:DeviceDetailedInformation;1"
+    },
+    {
+      "@type": "Component",
+      "name": "Sensors_Information",
+      "schema": "dtmi:Advantech:SensorsInformation;2"
+    },
+    {
+      "@type": "Component",
+      "name": "deviceInfo",
+      "schema": "dtmi:azure:DeviceManagement:DeviceInformation;1"
+    },
+    {
+      "@type": "Component",
+      "name": "GPIO",
+      "schema": "dtmi:Advantech:GPIO;1"
+    },
+    {
+      "@type": "Component",
+      "name": "VGA",
+      "schema": "dtmi:Advantech:VGA;1"
+    },
+    {
+      "@type": "Component",
+      "name": "SDRAM",
+      "schema": "dtmi:Advantech:SDRAM;1"
+    }
+  ]
+}

--- a/dtmi/advantech/sdram-1.json
+++ b/dtmi/advantech/sdram-1.json
@@ -1,0 +1,132 @@
+{
+  "@id": "dtmi:Advantech:SDRAM;1",
+  "@type": "Interface",
+  "displayName": "SDRAM",
+  "@context": "dtmi:dtdl:context;2",
+  "contents": [
+    {
+      "@type": "Command",
+      "name": "GET_PARTNUMBER",
+      "response": {
+        "name": "VALUE",
+        "schema": "string"
+      }
+    },
+    {
+      "@type": "Command",
+      "name": "GET_MEMORYTYPE",
+      "response": {
+        "name": "VALUE",
+        "schema": "string"
+      }
+    },
+    {
+      "@type": "Command",
+      "name": "GET_MEMORYSPEED",
+      "response": {
+        "name": "VALUE",
+        "schema": "integer"
+      }
+    },
+    {
+      "@type": "Command",
+      "name": "GET_MODULETYPE",
+      "response": {
+        "name": "VALUE",
+        "schema": "string"
+      }
+    },
+    {
+      "@type": "Command",
+      "name": "GET_MODULESIZE",
+      "response": {
+        "name": "VALUE",
+        "schema": "integer"
+      }
+    },
+    {
+      "@type": "Command",
+      "name": "GET_WEEKYEAR",
+      "response": {
+        "name": "VALUE",
+        "schema": "string"
+      }
+    },
+    {
+      "@type": "Command",
+      "name": "GET_RANK",
+      "response": {
+        "name": "VALUE",
+        "schema": "integer"
+      }
+    },
+    {
+      "@type": "Command",
+      "name": "GET_BANK",
+      "response": {
+        "name": "VALUE",
+        "schema": "integer"
+      }
+    },
+    {
+      "@type": "Command",
+      "name": "GET_VOLTAGE",
+      "response": {
+        "name": "VALUE",
+        "schema": "double"
+      }
+    },
+    {
+      "@type": "Command",
+      "name": "GET_TEMPRATURE",
+      "response": {
+        "name": "VALUE",
+        "schema": "double"
+      }
+    },
+    {
+      "@type": "Command",
+      "name": "GET_MODULEMANUFACTURE",
+      "response": {
+        "name": "VALUE",
+        "schema": "string"
+      }
+    },
+    {
+      "@type": "Command",
+      "name": "GET_DRAMMANUFACTURE",
+      "response": {
+        "name": "VALUE",
+        "schema": "string"
+      }
+    },
+    {
+      "@type": "Command",
+      "name": "GET_WRITEPROTECTION",
+      "response": {
+        "name": "VALUE",
+        "schema": "string"
+      }
+    },
+    {
+      "@type": "Command",
+      "name": "SET_SOCKET",
+      "request": {
+        "name": "VALUE",
+        "schema": "integer"
+      },
+      "response": {
+        "name": "VALUE",
+        "schema": "integer"
+      }
+    },
+    {
+      "@type": "Command",
+      "name": "GET_SOCKET",
+      "response": {
+        "name": "VALUE",
+        "schema": "integer"
+      }
+    }
+  ]
+}

--- a/dtmi/advantech/sensorsinformation-1.json
+++ b/dtmi/advantech/sensorsinformation-1.json
@@ -1,0 +1,128 @@
+{
+  "@id": "dtmi:Advantech:SensorsInformation;1",
+  "@type": "Interface",
+  "displayName": "Sensor Information",
+  "@context": "dtmi:dtdl:context;2",
+  "contents": [
+    {
+      "@type": "Telemetry",
+      "displayName": "Voltage Vcore",
+      "name": "vvcore",
+      "schema": "double"
+    },
+    {
+      "@type": "Telemetry",
+      "displayName": "Voltage Vcore2",
+      "name": "vvcore2",
+      "schema": "double"
+    },
+    {
+      "@type": "Telemetry",
+      "displayName": "Voltage 2.5V",
+      "name": "v25v",
+      "schema": "double"
+    },
+    {
+      "@type": "Telemetry",
+      "displayName": "Voltage 3.3V",
+      "name": "v33v",
+      "schema": "double"
+    },
+    {
+      "@type": "Telemetry",
+      "displayName": "Voltage 5V",
+      "name": "v5v",
+      "schema": "double"
+    },
+    {
+      "@type": "Telemetry",
+      "displayName": "Voltage 12V",
+      "name": "v12v",
+      "schema": "double"
+    },
+    {
+      "@type": "Telemetry",
+      "displayName": "Voltage 5V Standby",
+      "name": "v5vstandby",
+      "schema": "double"
+    },
+    {
+      "@type": "Telemetry",
+      "displayName": "Voltage 3V Standby",
+      "name": "v3vstandby",
+      "schema": "double"
+    },
+    {
+      "@type": "Telemetry",
+      "displayName": "Voltage CMOS Battery",
+      "name": "vcmosbattery",
+      "schema": "double"
+    },
+    {
+      "@type": "Telemetry",
+      "displayName": "Voltage -5v",
+      "name": "v5nv",
+      "schema": "double"
+    },
+    {
+      "@type": "Telemetry",
+      "displayName": "Voltage -12v",
+      "name": "v12nv",
+      "schema": "double"
+    },
+    {
+      "@type": "Telemetry",
+      "displayName": "DIMM voltage",
+      "name": "vvtt",
+      "schema": "double"
+    },
+    {
+      "@type": "Telemetry",
+      "displayName": "Voltage 24v",
+      "name": "v24v",
+      "schema": "double"
+    },
+    {
+      "@type": "Telemetry",
+      "displayName": "Temperature CPU",
+      "name": "tcpu",
+      "schema": "double"
+    },
+    {
+      "@type": "Telemetry",
+      "displayName": "Temperature Chipset",
+      "name": "tchipset",
+      "schema": "double"
+    },
+    {
+      "@type": "Telemetry",
+      "displayName": "Temperature System",
+      "name": "tsystem",
+      "schema": "double"
+    },
+    {
+      "@type": "Telemetry",
+      "displayName": "Temperature CPU2",
+      "name": "tcpu2",
+      "schema": "double"
+    },
+    {
+      "@type": "Telemetry",
+      "displayName": "Fan CPU",
+      "name": "fcpu",
+      "schema": "double"
+    },
+    {
+      "@type": "Telemetry",
+      "displayName": "Fan System",
+      "name": "fsystem",
+      "schema": "double"
+    },
+    {
+      "@type": "Telemetry",
+      "displayName": "Fan CPU2",
+      "name": "fcpu2",
+      "schema": "double"
+    }
+  ]
+}

--- a/dtmi/advantech/sensorsinformation-2.json
+++ b/dtmi/advantech/sensorsinformation-2.json
@@ -1,0 +1,208 @@
+{
+  "@id": "dtmi:Advantech:SensorsInformation;2",
+  "@type": "Interface",
+  "displayName": "Sensor Information",
+  "@context": "dtmi:dtdl:context;2",
+  "contents": [
+    {
+      "@type": [
+        "Telemetry",
+        "Voltage"
+      ],
+      "displayName": "Voltage Vcore",
+      "name": "vvcore",
+      "schema": "double",
+      "unit": "volt"
+    },
+    {
+      "@type": [
+        "Telemetry",
+        "Voltage"
+      ],
+      "displayName": "Voltage Vcore2",
+      "name": "vvcore2",
+      "schema": "double",
+      "unit": "volt"
+    },
+    {
+      "@type": [
+        "Telemetry",
+        "Voltage"
+      ],
+      "displayName": "Voltage 2.5V",
+      "name": "v25v",
+      "schema": "double",
+      "unit": "volt"
+    },
+    {
+      "@type": [
+        "Telemetry",
+        "Voltage"
+      ],
+      "displayName": "Voltage 3.3V",
+      "name": "v33v",
+      "schema": "double",
+      "unit": "volt"
+    },
+    {
+      "@type": [
+        "Telemetry",
+        "Voltage"
+      ],
+      "displayName": "Voltage 5V",
+      "name": "v5v",
+      "schema": "double",
+      "unit": "volt"
+    },
+    {
+      "@type": [
+        "Telemetry",
+        "Voltage"
+      ],
+      "displayName": "Voltage 12V",
+      "name": "v12v",
+      "schema": "double",
+      "unit": "volt"
+    },
+    {
+      "@type": [
+        "Telemetry",
+        "Voltage"
+      ],
+      "displayName": "Voltage 5V Standby",
+      "name": "v5vstandby",
+      "schema": "double",
+      "unit": "volt"
+    },
+    {
+      "@type": [
+        "Telemetry",
+        "Voltage"
+      ],
+      "displayName": "Voltage 3V Standby",
+      "name": "v3vstandby",
+      "schema": "double",
+      "unit": "volt"
+    },
+    {
+      "@type": [
+        "Telemetry",
+        "Voltage"
+      ],
+      "displayName": "Voltage CMOS Battery",
+      "name": "vcmosbattery",
+      "schema": "double",
+      "unit": "volt"
+    },
+    {
+      "@type": [
+        "Telemetry",
+        "Voltage"
+      ],
+      "displayName": "Voltage -5v",
+      "name": "v5nv",
+      "schema": "double",
+      "unit": "volt"
+    },
+    {
+      "@type": [
+        "Telemetry",
+        "Voltage"
+      ],
+      "displayName": "Voltage -12v",
+      "name": "v12nv",
+      "schema": "double",
+      "unit": "volt"
+    },
+    {
+      "@type": [
+        "Telemetry",
+        "Voltage"
+      ],
+      "displayName": "DIMM voltage",
+      "name": "vvtt",
+      "schema": "double",
+      "unit": "volt"
+    },
+    {
+      "@type": [
+        "Telemetry",
+        "Voltage"
+      ],
+      "displayName": "Voltage 24v",
+      "name": "v24v",
+      "schema": "double",
+      "unit": "volt"
+    },
+    {
+      "@type": [
+        "Telemetry",
+        "Temperature"
+      ],
+      "displayName": "Temperature CPU",
+      "name": "tcpu",
+      "schema": "double",
+      "unit": "degreeCelsius"
+    },
+    {
+      "@type": [
+        "Telemetry",
+        "Temperature"
+      ],
+      "displayName": "Temperature Chipset",
+      "name": "tchipset",
+      "schema": "double",
+      "unit": "degreeCelsius"
+    },
+    {
+      "@type": [
+        "Telemetry",
+        "Temperature"
+      ],
+      "displayName": "Temperature System",
+      "name": "tsystem",
+      "schema": "double",
+      "unit": "degreeCelsius"
+    },
+    {
+      "@type": [
+        "Telemetry",
+        "Temperature"
+      ],
+      "displayName": "Temperature CPU2",
+      "name": "tcpu2",
+      "schema": "double",
+      "unit": "degreeCelsius"
+    },
+    {
+      "@type": [
+        "Telemetry",
+        "AngularVelocity"
+      ],
+      "displayName": "Fan CPU",
+      "name": "fcpu",
+      "schema": "double",
+      "unit": "revolutionPerMinute"
+    },
+    {
+      "@type": [
+        "Telemetry",
+        "AngularVelocity"
+      ],
+      "displayName": "Fan System",
+      "name": "fsystem",
+      "schema": "double",
+      "unit": "revolutionPerMinute"
+    },
+    {
+      "@type": [
+        "Telemetry",
+        "AngularVelocity"
+      ],
+      "displayName": "Fan CPU2",
+      "name": "fcpu2",
+      "schema": "double",
+      "unit": "revolutionPerMinute"
+    }
+  ]
+}

--- a/dtmi/advantech/utc_520-1.json
+++ b/dtmi/advantech/utc_520-1.json
@@ -1,0 +1,23 @@
+{
+  "@id": "dtmi:Advantech:UTC_520;1",
+  "@type": "Interface",
+  "displayName": "UTC-520",
+  "@context": "dtmi:dtdl:context;2",
+  "contents": [
+    {
+      "@type": "Component",
+      "name": "Device_Detailed_Information",
+      "schema": "dtmi:Advantech:DeviceDetailedInformation;1"
+    },
+    {
+      "@type": "Component",
+      "name": "Sensors_Information",
+      "schema": "dtmi:Advantech:SensorsInformation;1"
+    },
+    {
+      "@type": "Component",
+      "name": "deviceInfo",
+      "schema": "dtmi:azure:DeviceManagement:DeviceInformation;1"
+    }
+  ]
+}

--- a/dtmi/advantech/utc_520-2.json
+++ b/dtmi/advantech/utc_520-2.json
@@ -1,0 +1,164 @@
+{
+  "@id": "dtmi:Advantech:UTC_520;2",
+  "@type": "Interface",
+  "displayName": "UTC-520",
+  "@context": "dtmi:dtdl:context;2",
+  "contents": [
+    {
+      "@type": "Property",
+      "displayName": "BIOS Version",
+      "name": "BiosVersion",
+      "schema": "string"
+    },
+    {
+      "@type": "Property",
+      "displayName": "EC Firmware",
+      "name": "ECFirmware",
+      "schema": "string"
+    },
+    {
+      "@type": "Property",
+      "displayName": "Driver Version",
+      "name": "DriverVersion",
+      "schema": "string"
+    },
+    {
+      "@type": "Property",
+      "displayName": "Library Version",
+      "name": "LibraryVersion",
+      "schema": "string"
+    },
+    {
+      "@type": "Property",
+      "displayName": "Firmware Version",
+      "name": "FirmwareVersion",
+      "schema": "string"
+    },
+    {
+      "@type": "Property",
+      "displayName": "Last Connected At",
+      "name": "LastConnectedAt",
+      "schema": "dateTime"
+    },
+    {
+      "@type": "Telemetry",
+      "displayName": "Voltage Vcore",
+      "name": "vvcore",
+      "schema": "double"
+    },
+    {
+      "@type": "Telemetry",
+      "displayName": "Voltage Vcore2",
+      "name": "vvcore2",
+      "schema": "double"
+    },
+    {
+      "@type": "Telemetry",
+      "displayName": "Voltage 2.5V",
+      "name": "v25v",
+      "schema": "double"
+    },
+    {
+      "@type": "Telemetry",
+      "displayName": "Voltage 3.3V",
+      "name": "v33v",
+      "schema": "double"
+    },
+    {
+      "@type": "Telemetry",
+      "displayName": "Voltage 5V",
+      "name": "v5v",
+      "schema": "double"
+    },
+    {
+      "@type": "Telemetry",
+      "displayName": "Voltage 12V",
+      "name": "v12v",
+      "schema": "double"
+    },
+    {
+      "@type": "Telemetry",
+      "displayName": "Voltage 5V Standby",
+      "name": "v5vstandby",
+      "schema": "double"
+    },
+    {
+      "@type": "Telemetry",
+      "displayName": "Voltage 3V Standby",
+      "name": "v3vstandby",
+      "schema": "double"
+    },
+    {
+      "@type": "Telemetry",
+      "displayName": "Voltage CMOS Battery",
+      "name": "vcmosbattery",
+      "schema": "double"
+    },
+    {
+      "@type": "Telemetry",
+      "displayName": "Voltage -5v",
+      "name": "v5nv",
+      "schema": "double"
+    },
+    {
+      "@type": "Telemetry",
+      "displayName": "Voltage -12v",
+      "name": "v12nv",
+      "schema": "double"
+    },
+    {
+      "@type": "Telemetry",
+      "displayName": "DIMM voltage",
+      "name": "vvtt",
+      "schema": "double"
+    },
+    {
+      "@type": "Telemetry",
+      "displayName": "Voltage 24v",
+      "name": "v24v",
+      "schema": "double"
+    },
+    {
+      "@type": "Telemetry",
+      "displayName": "Temperature CPU",
+      "name": "tcpu",
+      "schema": "double"
+    },
+    {
+      "@type": "Telemetry",
+      "displayName": "Temperature Chipset",
+      "name": "tchipset",
+      "schema": "double"
+    },
+    {
+      "@type": "Telemetry",
+      "displayName": "Temperature System",
+      "name": "tsystem",
+      "schema": "double"
+    },
+    {
+      "@type": "Telemetry",
+      "displayName": "Temperature CPU2",
+      "name": "tcpu2",
+      "schema": "double"
+    },
+    {
+      "@type": "Telemetry",
+      "displayName": "Fan CPU",
+      "name": "fcpu",
+      "schema": "double"
+    },
+    {
+      "@type": "Telemetry",
+      "displayName": "Fan System",
+      "name": "fsystem",
+      "schema": "double"
+    },
+    {
+      "@type": "Telemetry",
+      "displayName": "Fan CPU2",
+      "name": "fcpu2",
+      "schema": "double"
+    }
+  ]
+}

--- a/dtmi/advantech/vga-1.json
+++ b/dtmi/advantech/vga-1.json
@@ -1,0 +1,128 @@
+{
+  "@id": "dtmi:Advantech:VGA;1",
+  "@type": "Interface",
+  "displayName": "VGA",
+  "@context": "dtmi:dtdl:context;2",
+  "contents": [
+    {
+      "@type": "Command",
+      "name": "SET_ID",
+      "request": {
+        "name": "ID",
+        "schema": "integer"
+      },
+      "response": {
+        "name": "ID",
+        "schema": "integer"
+      }
+    },
+    {
+      "@type": "Command",
+      "name": "GET_ID",
+      "response": {
+        "name": "ID",
+        "schema": "integer"
+      }
+    },
+    {
+      "@type": "Command",
+      "name": "SET_ENABLE",
+      "request": {
+        "name": "VALUE",
+        "schema": "integer"
+      },
+      "response": {
+        "name": "VALUE",
+        "schema": "integer"
+      }
+    },
+    {
+      "@type": "Command",
+      "name": "GET_ENABLE",
+      "response": {
+        "name": "VALUE",
+        "schema": "integer"
+      }
+    },
+    {
+      "@type": "Command",
+      "name": "SET_BRIGHTNESS",
+      "request": {
+        "name": "VALUE",
+        "schema": "integer"
+      },
+      "response": {
+        "name": "VALUE",
+        "schema": "integer"
+      }
+    },
+    {
+      "@type": "Command",
+      "name": "GET_BRIGHTNESS",
+      "response": {
+        "name": "VALUE",
+        "schema": "integer"
+      }
+    },
+    {
+      "@type": "Command",
+      "name": "SET_LEVEL",
+      "request": {
+        "name": "VALUE",
+        "schema": "integer"
+      },
+      "response": {
+        "name": "VALUE",
+        "schema": "integer"
+      }
+    },
+    {
+      "@type": "Command",
+      "name": "GET_LEVEL",
+      "response": {
+        "name": "VALUE",
+        "schema": "integer"
+      }
+    },
+    {
+      "@type": "Command",
+      "name": "SET_POLARITY",
+      "request": {
+        "name": "VALUE",
+        "schema": "integer"
+      },
+      "response": {
+        "name": "VALUE",
+        "schema": "integer"
+      }
+    },
+    {
+      "@type": "Command",
+      "name": "GET_POLARITY",
+      "response": {
+        "name": "VALUE",
+        "schema": "integer"
+      }
+    },
+    {
+      "@type": "Command",
+      "name": "SET_FREQUENCY",
+      "request": {
+        "name": "VALUE",
+        "schema": "integer"
+      },
+      "response": {
+        "name": "VALUE",
+        "schema": "integer"
+      }
+    },
+    {
+      "@type": "Command",
+      "name": "GET_FREQUENCY",
+      "response": {
+        "name": "VALUE",
+        "schema": "integer"
+      }
+    }
+  ]
+}

--- a/dtmi/allegion/lockconfig-1.json
+++ b/dtmi/allegion/lockconfig-1.json
@@ -1,0 +1,71 @@
+{
+  "@context": "dtmi:dtdl:context;2",
+  "@id": "dtmi:Allegion:LockConfig;1",
+  "@type": "Interface",
+  "displayName": "LockConfig",
+  "contents": [
+    {
+      "@id": "dtmi:Allegion:LockConfig:Name;1",
+      "@type": "Property",
+      "displayName": {
+        "en": "Name"
+      },
+      "name": "Name",
+      "schema": "string"
+    },
+    {
+      "@id": "dtmi:Allegion:LockConfig:LockSerialNumber;1",
+      "@type": "Property",
+      "displayName": {
+        "en": "LockSerialNumber"
+      },
+      "name": "LockSerialNumber",
+      "schema": "string"
+    },
+    {
+      "@id": "dtmi:Allegion:LockConfig:MainSerialNumber;1",
+      "@type": "Property",
+      "displayName": {
+        "en": "MainSerialNumber"
+      },
+      "name": "MainSerialNumber",
+      "schema": "string"
+    },
+    {
+      "@id": "dtmi:Allegion:LockConfig:HardwareVersion;1",
+      "@type": "Property",
+      "displayName": {
+        "en": "HardwareVersion"
+      },
+      "name": "HardwareVersion",
+      "schema": "string"
+    },
+    {
+      "@id": "dtmi:Allegion:LockConfig:RelockDelay;1",
+      "@type": "Property",
+      "displayName": {
+        "en": "RelockDelay"
+      },
+      "name": "RelockDelay",
+      "schema": "time"
+    },
+    {
+      "@id": "dtmi:Allegion:LockConfig:DoorPropDelay;1",
+      "@type": "Property",
+      "displayName": {
+        "en": "DoorPropDelay"
+      },
+      "name": "DoorPropDelay",
+      "schema": "time"
+    },
+    {
+      "@id": "dtmi:Allegion:LockConfig:AdaDelay;1",
+      "@type": "Property",
+      "displayName": {
+        "en": "AdaDelay"
+      },
+      "name": "AdaDelay",
+      "schema": "time"
+    }
+  ]
+}

--- a/dtmi/brainium/smartedgeagile-1.json
+++ b/dtmi/brainium/smartedgeagile-1.json
@@ -1,0 +1,133 @@
+{
+  "@context": "dtmi:dtdl:context;2",
+  "@id": "dtmi:Brainium:SmartEdgeAgile;1",
+  "@type": "Interface",
+  "displayName": "SmartEdgeAgile",
+  "description": "Multi sensor IoT device",
+  "contents": [
+    {
+      "@type": [
+        "Telemetry",
+        "Acceleration"
+      ],
+      "name": "normalAcceleration",
+      "displayName": "Normal Acceleration",
+      "description": "Normal acceleration module in m/c^2.",
+      "schema": "double",
+      "unit": "metrePerSecondSquared"
+    },
+    {
+      "@type": [
+        "Telemetry",
+        "Acceleration"
+      ],
+      "name": "worldAcceleration",
+      "displayName": "World Acceleration",
+      "description": "World acceleration module in m/c^2.",
+      "schema": "double",
+      "unit": "metrePerSecondSquared"
+    },
+    {
+      "@type": [
+        "Telemetry",
+        "Pressure"
+      ],
+      "name": "pressure",
+      "displayName": "Atmosphere pressure",
+      "description": "Atmosphere pressure in Pa.",
+      "schema": "double",
+      "unit": "pascal"
+    },
+    {
+      "@type": [
+        "Telemetry",
+        "AngularVelocity"
+      ],
+      "name": "angularVelocity",
+      "displayName": "Angular velocity",
+      "description": "Angular velocity in deg/s.",
+      "schema": "double",
+      "unit": "degreePerSecond"
+    },
+    {
+      "@type": [
+        "Telemetry",
+        "Illuminance"
+      ],
+      "name": "infraredIlluminance",
+      "displayName": "Infrared Illuminance",
+      "description": "Infrared Illuminance in lx.",
+      "schema": "double",
+      "unit": "lux"
+    },
+    {
+      "@type": [
+        "Telemetry",
+        "Illuminance"
+      ],
+      "name": "visibleIlluminance",
+      "displayName": "Visible Illuminance",
+      "description": "Visible Illuminance in lx.",
+      "schema": "double",
+      "unit": "lux"
+    },
+    {
+      "@type": [
+        "Telemetry",
+        "MagneticInduction"
+      ],
+      "name": "magneticInduction",
+      "displayName": "Magnetic induction",
+      "description": "Magnetic induction in T.",
+      "schema": "double",
+      "unit": "tesla"
+    },
+    {
+      "@type": [
+        "Telemetry",
+        "RelativeHumidity"
+      ],
+      "name": "humidity",
+      "displayName": "Humidity",
+      "description": "Humidity in %.",
+      "schema": "double",
+      "unit": "percent"
+    },
+    {
+      "@type": [
+        "Telemetry",
+        "Distance"
+      ],
+      "name": "distance",
+      "displayName": "Distance",
+      "description": "Distance in centimetre.",
+      "schema": "double",
+      "unit": "centimetre"
+    },
+    {
+      "@type": [
+        "Telemetry",
+        "Temperature"
+      ],
+      "name": "temperature",
+      "displayName": "Temperature",
+      "description": "Temperature in Celsius.",
+      "schema": "double",
+      "unit": "degreeCelsius"
+    },
+    {
+      "@type": "Command",
+      "name": "tracking",
+      "request": {
+        "name": "Tracking",
+        "displayName": "Tracking",
+        "description": "Start or stop tracking.",
+        "schema": "boolean"
+      },
+      "response": {
+        "name": "result",
+        "schema": "integer"
+      }
+    }
+  ]
+}

--- a/dtmi/com/octonion/smartedgeagiledevice-1.json
+++ b/dtmi/com/octonion/smartedgeagiledevice-1.json
@@ -1,0 +1,133 @@
+{
+  "@context": "dtmi:dtdl:context;2",
+  "@id": "dtmi:com:Octonion:SmartEdgeAgileDevice;1",
+  "@type": "Interface",
+  "displayName": "SmartEdgeAgile",
+  "description": "Multi sensor IoT device",
+  "contents": [
+    {
+      "@type": [
+        "Telemetry",
+        "Acceleration"
+      ],
+      "name": "normalAcceleration",
+      "displayName": "Normal Acceleration",
+      "description": "Normal acceleration module in m/c^2.",
+      "schema": "double",
+      "unit": "metrePerSecondSquared"
+    },
+    {
+      "@type": [
+        "Telemetry",
+        "Acceleration"
+      ],
+      "name": "worldAcceleration",
+      "displayName": "World Acceleration",
+      "description": "World acceleration module in m/c^2.",
+      "schema": "double",
+      "unit": "metrePerSecondSquared"
+    },
+    {
+      "@type": [
+        "Telemetry",
+        "Pressure"
+      ],
+      "name": "pressure",
+      "displayName": "Atmosphere pressure",
+      "description": "Atmosphere pressure in Pa.",
+      "schema": "double",
+      "unit": "pascal"
+    },
+    {
+      "@type": [
+        "Telemetry",
+        "AngularVelocity"
+      ],
+      "name": "angularVelocity",
+      "displayName": "Angular velocity",
+      "description": "Angular velocity in deg/s.",
+      "schema": "double",
+      "unit": "degreePerSecond"
+    },
+    {
+      "@type": [
+        "Telemetry",
+        "Illuminance"
+      ],
+      "name": "infraredIlluminance",
+      "displayName": "Infrared Illuminance",
+      "description": "Infrared Illuminance in lx.",
+      "schema": "double",
+      "unit": "lux"
+    },
+    {
+      "@type": [
+        "Telemetry",
+        "Illuminance"
+      ],
+      "name": "visibleIlluminance",
+      "displayName": "Visible Illuminance",
+      "description": "Visible Illuminance in lx.",
+      "schema": "double",
+      "unit": "lux"
+    },
+    {
+      "@type": [
+        "Telemetry",
+        "MagneticInduction"
+      ],
+      "name": "magneticInduction",
+      "displayName": "Magnetic induction",
+      "description": "Magnetic induction in T.",
+      "schema": "double",
+      "unit": "tesla"
+    },
+    {
+      "@type": [
+        "Telemetry",
+        "RelativeHumidity"
+      ],
+      "name": "humidity",
+      "displayName": "Humidity",
+      "description": "Humidity in %.",
+      "schema": "double",
+      "unit": "percent"
+    },
+    {
+      "@type": [
+        "Telemetry",
+        "Distance"
+      ],
+      "name": "distance",
+      "displayName": "Distance",
+      "description": "Distance in centimetre.",
+      "schema": "double",
+      "unit": "centimetre"
+    },
+    {
+      "@type": [
+        "Telemetry",
+        "Temperature"
+      ],
+      "name": "temperature",
+      "displayName": "Temperature",
+      "description": "Temperature in degreeCelsius.",
+      "schema": "double",
+      "unit": "degreeCelsius"
+    },
+    {
+      "@type": "Command",
+      "name": "tracking",
+      "request": {
+        "name": "Tracking",
+        "displayName": "Tracking",
+        "description": "Start or stop tracking.",
+        "schema": "boolean"
+      },
+      "response": {
+        "name": "result",
+        "schema": "integer"
+      }
+    }
+  ]
+}

--- a/dtmi/espressif/deviceinformation-1.json
+++ b/dtmi/espressif/deviceinformation-1.json
@@ -1,0 +1,64 @@
+{
+  "@context": "dtmi:dtdl:context;2",
+  "@id": "dtmi:Espressif:DeviceInformation;1",
+  "@type": "Interface",
+  "displayName": "Device Information",
+  "contents": [
+    {
+      "@type": "Property",
+      "name": "manufacturer",
+      "displayName": "Manufacturer",
+      "schema": "string",
+      "description": "Company name of the device manufacturer. This could be the same as the name of the original equipment manufacturer (OEM). Ex. Espressif."
+    },
+    {
+      "@type": "Property",
+      "name": "model",
+      "displayName": "Device model",
+      "schema": "string",
+      "description": "Device model name. Ex. Espressif."
+    },
+    {
+      "@type": "Property",
+      "name": "swVersion",
+      "displayName": "Software version",
+      "schema": "string",
+      "description": "Version of the software on your device. This could be the version of your firmware. Ex. 1.0.0."
+    },
+    {
+      "@type": "Property",
+      "name": "osName",
+      "displayName": "Operating system name",
+      "schema": "string",
+      "description": "Name of the operating system on the device. Ex. FreeRTOS."
+    },
+    {
+      "@type": "Property",
+      "name": "processorArchitecture",
+      "displayName": "Processor architecture",
+      "schema": "string",
+      "description": "Architecture of the processor on the device. Ex. Xtensa."
+    },
+    {
+      "@type": "Property",
+      "name": "processorManufacturer",
+      "displayName": "Processor manufacturer",
+      "schema": "string",
+      "description": "Name of the manufacturer of the processor on the device. Ex. Xtensa."
+    },
+    {
+      "@type": "Property",
+      "name": "totalStorage",
+      "displayName": "Total storage",
+      "schema": "double",
+      "description": "Total available storage on the device in kilobytes. Ex. 2048000 kilobytes."
+    },
+    {
+      "@type": "Property",
+      "name": "totalMemory",
+      "displayName": "Total memory",
+      "schema": "double",
+      "description": "Total available memory on the device in kilobytes. Ex. 256000 kilobytes."
+    }
+  ]
+}

--- a/dtmi/espressif/deviceinformation-2.json
+++ b/dtmi/espressif/deviceinformation-2.json
@@ -1,0 +1,64 @@
+{
+  "@context": "dtmi:dtdl:context;2",
+  "@id": "dtmi:Espressif:DeviceInformation;2",
+  "@type": "Interface",
+  "displayName": "Device Information",
+  "contents": [
+    {
+      "@type": "Property",
+      "name": "manufacturer",
+      "displayName": "Manufacturer",
+      "schema": "string",
+      "description": "Company name of the device manufacturer is Espressif."
+    },
+    {
+      "@type": "Property",
+      "name": "model",
+      "displayName": "Device model",
+      "schema": "string",
+      "description": "Device model name on the device is Espressif."
+    },
+    {
+      "@type": "Property",
+      "name": "swVersion",
+      "displayName": "Software version",
+      "schema": "string",
+      "description": "Version of the software on the device is 1.0.0."
+    },
+    {
+      "@type": "Property",
+      "name": "osName",
+      "displayName": "Operating system name",
+      "schema": "string",
+      "description": "Name of the operating system on the device is FreeRTOS."
+    },
+    {
+      "@type": "Property",
+      "name": "processorArchitecture",
+      "displayName": "Processor architecture",
+      "schema": "string",
+      "description": "Architecture of the processor on the device is Xtensa."
+    },
+    {
+      "@type": "Property",
+      "name": "processorManufacturer",
+      "displayName": "Processor manufacturer",
+      "schema": "string",
+      "description": "Name of the manufacturer of the processor on the device is Xtensa."
+    },
+    {
+      "@type": "Property",
+      "name": "totalStorage",
+      "displayName": "Total storage",
+      "schema": "double",
+      "description": "Total available storage on the device."
+    },
+    {
+      "@type": "Property",
+      "name": "totalMemory",
+      "displayName": "Total memory",
+      "schema": "double",
+      "description": "Total available memory on the device."
+    }
+  ]
+}

--- a/dtmi/espressif/sensoraltitude-1.json
+++ b/dtmi/espressif/sensoraltitude-1.json
@@ -1,0 +1,89 @@
+{
+  "@context": "dtmi:dtdl:context;2",
+  "@id": "dtmi:Espressif:SensorAltitude;1",
+  "@type": "Interface",
+  "displayName": "SensorAltitude",
+  "description": "Reports current temperature and provides desired temperature control.",
+  "contents": [
+    {
+      "@type": [
+        "Telemetry",
+        "Temperature"
+      ],
+      "name": "temperature",
+      "displayName": "Temperature",
+      "description": "Temperature in degrees Celsius.",
+      "schema": "double",
+      "unit": "degreeCelsius"
+    },
+    {
+      "@type": [
+        "Property",
+        "Temperature"
+      ],
+      "name": "targetTemperature",
+      "schema": "double",
+      "displayName": "Target Temperature",
+      "description": "Allows to remotely specify the desired target temperature.",
+      "unit": "degreeCelsius",
+      "writable": true
+    },
+    {
+      "@type": [
+        "Property",
+        "Temperature"
+      ],
+      "name": "maxTempSinceLastReboot",
+      "schema": "double",
+      "unit": "degreeCelsius",
+      "displayName": "Max temperature since last reboot.",
+      "description": "Returns the max temperature since last device reboot."
+    },
+    {
+      "@type": "Command",
+      "name": "getMaxMinReport",
+      "displayName": "Get Max-Min report.",
+      "description": "This command returns the max, min and average temperature from the specified time to the current time.",
+      "request": {
+        "name": "since",
+        "displayName": "Since",
+        "description": "Period to return the max-min report.",
+        "schema": "dateTime"
+      },
+      "response": {
+        "name": "tempReport",
+        "displayName": "Temperature Report",
+        "schema": {
+          "@type": "Object",
+          "fields": [
+            {
+              "name": "maxTemp",
+              "displayName": "Max temperature",
+              "schema": "double"
+            },
+            {
+              "name": "minTemp",
+              "displayName": "Min temperature",
+              "schema": "double"
+            },
+            {
+              "name": "avgTemp",
+              "displayName": "Average Temperature",
+              "schema": "double"
+            },
+            {
+              "name": "startTime",
+              "displayName": "Start Time",
+              "schema": "dateTime"
+            },
+            {
+              "name": "endTime",
+              "displayName": "End Time",
+              "schema": "dateTime"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/dtmi/espressif/sensoraltitude-2.json
+++ b/dtmi/espressif/sensoraltitude-2.json
@@ -1,0 +1,19 @@
+{
+  "@context": "dtmi:dtdl:context;2",
+  "@id": "dtmi:Espressif:SensorAltitude;2",
+  "@type": "Interface",
+  "displayName": "SensorAltitude",
+  "description": "Current altitude on the device",
+  "contents": [
+    {
+      "@type": [
+        "Telemetry",
+        "Length"
+      ],
+      "name": "SensorAltitude",
+      "displayName": "SensorAltitude",
+      "schema": "double",
+      "unit": "metre"
+    }
+  ]
+}

--- a/dtmi/espressif/sensorcontroller-1.json
+++ b/dtmi/espressif/sensorcontroller-1.json
@@ -1,0 +1,130 @@
+{
+  "@context": "dtmi:dtdl:context;2",
+  "@id": "dtmi:Espressif:SensorController;1",
+  "@type": "Interface",
+  "displayName": "Sensor Controller",
+  "description": "Device with two thermostats and remote reboot.",
+  "contents": [
+    {
+      "@type": [
+        "Telemetry",
+        "DataSize"
+      ],
+      "name": "workingSet",
+      "displayName": "Working Set",
+      "description": "Current working set of the device memory in KiB.",
+      "schema": "double",
+      "unit": "kibibyte"
+    },
+    {
+      "@type": "Property",
+      "name": "serialNumber",
+      "displayName": "Serial Number",
+      "description": "Serial number of the device.",
+      "schema": "string"
+    },
+    {
+      "@type": "Command",
+      "name": "reboot",
+      "displayName": "Reboot",
+      "description": "Reboots the device after waiting the number of seconds specified.",
+      "request": {
+        "name": "delay",
+        "displayName": "Delay",
+        "description": "Number of seconds to wait before rebooting the device.",
+        "schema": "integer"
+      }
+    },
+    {
+      "@type": "Component",
+      "name": "SensorAltitude",
+      "displayName": "SensorAltitude",
+      "description": "Current Altitude on the device.",
+      "schema": "dtmi:Espressif:SensorAltitude;1"
+    },
+    {
+      "@type": "Component",
+      "name": "SensorFanSpeed",
+      "displayName": "SensorFanSpeed",
+      "description": "Current Fan Speed on the device.",
+      "schema": "dtmi:Espressif:SensorFanSpeed;1"
+    },
+    {
+      "@type": "Component",
+      "name": "SensorHumid",
+      "displayName": "SensorHumid",
+      "description": "Current Humidity on the device.",
+      "schema": "dtmi:Espressif:SensorHumid;1"
+    },
+    {
+      "@type": "Component",
+      "name": "SensorLight",
+      "displayName": "SensorLight",
+      "description": "Current AmbientLight on the device.",
+      "schema": "dtmi:Espressif:SensorLight;1"
+    },
+    {
+      "@type": "Component",
+      "name": "SensorMagnetX",
+      "displayName": "SensorMagnetX",
+      "description": "Current MagnetometerX on the device.",
+      "schema": "dtmi:Espressif:SensorMagnetX;1"
+    },
+    {
+      "@type": "Component",
+      "name": "SensorMagnetY",
+      "displayName": "SensorMagnetY",
+      "description": " Current MagnetometerY on the device.",
+      "schema": "dtmi:Espressif:SensorMagnetY;1"
+    },
+    {
+      "@type": "Component",
+      "name": "SensorMagnetZ",
+      "displayName": "SensorMagnetZ",
+      "description": "Current MagnetometerZ on the device.",
+      "schema": "dtmi:Espressif:SensorMagnetZ;1"
+    },
+    {
+      "@type": "Component",
+      "name": "SensorPitch",
+      "displayName": "SensorPitch",
+      "description": "Current Pitch on the device.",
+      "schema": "dtmi:Espressif:SensorPitch;1"
+    },
+    {
+      "@type": "Component",
+      "name": "SensorPressure",
+      "displayName": "SensorPressure",
+      "description": "Current Pressure on the device.",
+      "schema": "dtmi:Espressif:SensorPressure;1"
+    },
+    {
+      "@type": "Component",
+      "name": "SensorRoll",
+      "displayName": "SensorRoll",
+      "description": "Current Roll on the device.",
+      "schema": "dtmi:Espressif:SensorRoll;1"
+    },
+    {
+      "@type": "Component",
+      "name": "SensorTemp",
+      "displayName": "SensorTemp",
+      "description": "Current Temperature on the device.",
+      "schema": "dtmi:Espressif:SensorTemp;1"
+    },
+    {
+      "@type": "Component",
+      "name": "SensorTempthreshold",
+      "displayName": "SensorTempthreshold",
+      "description": "Current Tempthreshold on the device.",
+      "schema": "dtmi:Espressif:SensorTempthreshold;1"
+    },
+    {
+      "@type": "Component",
+      "name": "deviceInformation",
+      "displayName": "Device Information interface",
+      "description": "Optional interface with basic device hardware information.",
+      "schema": "dtmi:Espressif:DeviceInformation;1"
+    }
+  ]
+}

--- a/dtmi/espressif/sensorcontroller-2.json
+++ b/dtmi/espressif/sensorcontroller-2.json
@@ -1,0 +1,116 @@
+{
+  "@context": "dtmi:dtdl:context;2",
+  "@id": "dtmi:Espressif:SensorController;2",
+  "@type": "Interface",
+  "displayName": "Sensor Controller",
+  "description": "Device with multiple sensors and remote reboot.",
+  "contents": [
+    {
+      "@type": [
+        "Telemetry",
+        "DataSize"
+      ],
+      "name": "workingSet",
+      "displayName": "Working Set",
+      "description": "Current working set of the device memory in KiB.",
+      "schema": "double",
+      "unit": "kibibyte"
+    },
+    {
+      "@type": "Property",
+      "name": "serialNumber",
+      "displayName": "Serial Number",
+      "description": "Serial number of the device.",
+      "schema": "string"
+    },
+    {
+      "@type": "Command",
+      "name": "reboot",
+      "displayName": "Reboot",
+      "description": "Reboots the device after waiting the number of seconds specified.",
+      "request": {
+        "name": "delay",
+        "displayName": "Delay",
+        "description": "Number of seconds to wait before rebooting the device.",
+        "schema": "integer"
+      }
+    },
+    {
+      "@type": "Component",
+      "name": "SensorAltitude",
+      "displayName": "SensorAltitude",
+      "description": "Current Altitude on the device.",
+      "schema": "dtmi:Espressif:SensorAltitude;2"
+    },
+    {
+      "@type": "Component",
+      "name": "SensorHumid",
+      "displayName": "SensorHumid",
+      "description": "Current Humidity on the device.",
+      "schema": "dtmi:Espressif:SensorHumid;2"
+    },
+    {
+      "@type": "Component",
+      "name": "SensorLight",
+      "displayName": "SensorLight",
+      "description": "Current AmbientLight on the device.",
+      "schema": "dtmi:Espressif:SensorLight;2"
+    },
+    {
+      "@type": "Component",
+      "name": "SensorMagnetX",
+      "displayName": "SensorMagnetX",
+      "description": "Current MagnetometerX on the device.",
+      "schema": "dtmi:Espressif:SensorMagnetX;2"
+    },
+    {
+      "@type": "Component",
+      "name": "SensorMagnetY",
+      "displayName": "SensorMagnetY",
+      "description": " Current MagnetometerY on the device.",
+      "schema": "dtmi:Espressif:SensorMagnetY;2"
+    },
+    {
+      "@type": "Component",
+      "name": "SensorMagnetZ",
+      "displayName": "SensorMagnetZ",
+      "description": "Current MagnetometerZ on the device.",
+      "schema": "dtmi:Espressif:SensorMagnetZ;2"
+    },
+    {
+      "@type": "Component",
+      "name": "SensorPitch",
+      "displayName": "SensorPitch",
+      "description": "Current Pitch on the device.",
+      "schema": "dtmi:Espressif:SensorPitch;2"
+    },
+    {
+      "@type": "Component",
+      "name": "SensorPressure",
+      "displayName": "SensorPressure",
+      "description": "Current Pressure on the device.",
+      "schema": "dtmi:Espressif:SensorPressure;2"
+    },
+    {
+      "@type": "Component",
+      "name": "SensorRoll",
+      "displayName": "SensorRoll",
+      "description": "Current Roll on the device.",
+      "schema": "dtmi:Espressif:SensorRoll;2"
+    },
+    {
+      "@type": "Component",
+      "name": "SensorTemp",
+      "displayName": "SensorTemp",
+      "description": "Current Temperature on the device.",
+      "schema": "dtmi:Espressif:SensorTemp;1"
+    },
+    {
+      "@type": "Component",
+      "name": "deviceInformation",
+      "displayName": "Device Information interface",
+      "description": "Optional interface with basic device hardware information.",
+      "schema": "dtmi:Espressif:DeviceInformation;2"
+    }
+  ]
+}

--- a/dtmi/espressif/sensorfanspeed-1.json
+++ b/dtmi/espressif/sensorfanspeed-1.json
@@ -1,0 +1,89 @@
+{
+  "@context": "dtmi:dtdl:context;2",
+  "@id": "dtmi:Espressif:SensorFanSpeed;1",
+  "@type": "Interface",
+  "displayName": "SensorFanSpeed",
+  "description": "Reports current temperature and provides desired temperature control.",
+  "contents": [
+    {
+      "@type": [
+        "Telemetry",
+        "Temperature"
+      ],
+      "name": "temperature",
+      "displayName": "Temperature",
+      "description": "Temperature in degrees Celsius.",
+      "schema": "double",
+      "unit": "degreeCelsius"
+    },
+    {
+      "@type": [
+        "Property",
+        "Temperature"
+      ],
+      "name": "targetTemperature",
+      "schema": "double",
+      "displayName": "Target Temperature",
+      "description": "Allows to remotely specify the desired target temperature.",
+      "unit": "degreeCelsius",
+      "writable": true
+    },
+    {
+      "@type": [
+        "Property",
+        "Temperature"
+      ],
+      "name": "maxTempSinceLastReboot",
+      "schema": "double",
+      "unit": "degreeCelsius",
+      "displayName": "Max temperature since last reboot.",
+      "description": "Returns the max temperature since last device reboot."
+    },
+    {
+      "@type": "Command",
+      "name": "getMaxMinReport",
+      "displayName": "Get Max-Min report.",
+      "description": "This command returns the max, min and average temperature from the specified time to the current time.",
+      "request": {
+        "name": "since",
+        "displayName": "Since",
+        "description": "Period to return the max-min report.",
+        "schema": "dateTime"
+      },
+      "response": {
+        "name": "tempReport",
+        "displayName": "Temperature Report",
+        "schema": {
+          "@type": "Object",
+          "fields": [
+            {
+              "name": "maxTemp",
+              "displayName": "Max temperature",
+              "schema": "double"
+            },
+            {
+              "name": "minTemp",
+              "displayName": "Min temperature",
+              "schema": "double"
+            },
+            {
+              "name": "avgTemp",
+              "displayName": "Average Temperature",
+              "schema": "double"
+            },
+            {
+              "name": "startTime",
+              "displayName": "Start Time",
+              "schema": "dateTime"
+            },
+            {
+              "name": "endTime",
+              "displayName": "End Time",
+              "schema": "dateTime"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/dtmi/espressif/sensorhumid-1.json
+++ b/dtmi/espressif/sensorhumid-1.json
@@ -1,0 +1,89 @@
+{
+  "@context": "dtmi:dtdl:context;2",
+  "@id": "dtmi:Espressif:SensorHumid;1",
+  "@type": "Interface",
+  "displayName": "SensorHumid",
+  "description": "Reports current temperature and provides desired temperature control.",
+  "contents": [
+    {
+      "@type": [
+        "Telemetry",
+        "Temperature"
+      ],
+      "name": "temperature",
+      "displayName": "Temperature",
+      "description": "Temperature in degrees Celsius.",
+      "schema": "double",
+      "unit": "degreeCelsius"
+    },
+    {
+      "@type": [
+        "Property",
+        "Temperature"
+      ],
+      "name": "targetTemperature",
+      "schema": "double",
+      "displayName": "Target Temperature",
+      "description": "Allows to remotely specify the desired target temperature.",
+      "unit": "degreeCelsius",
+      "writable": true
+    },
+    {
+      "@type": [
+        "Property",
+        "Temperature"
+      ],
+      "name": "maxTempSinceLastReboot",
+      "schema": "double",
+      "unit": "degreeCelsius",
+      "displayName": "Max temperature since last reboot.",
+      "description": "Returns the max temperature since last device reboot."
+    },
+    {
+      "@type": "Command",
+      "name": "getMaxMinReport",
+      "displayName": "Get Max-Min report.",
+      "description": "This command returns the max, min and average temperature from the specified time to the current time.",
+      "request": {
+        "name": "since",
+        "displayName": "Since",
+        "description": "Period to return the max-min report.",
+        "schema": "dateTime"
+      },
+      "response": {
+        "name": "tempReport",
+        "displayName": "Temperature Report",
+        "schema": {
+          "@type": "Object",
+          "fields": [
+            {
+              "name": "maxTemp",
+              "displayName": "Max temperature",
+              "schema": "double"
+            },
+            {
+              "name": "minTemp",
+              "displayName": "Min temperature",
+              "schema": "double"
+            },
+            {
+              "name": "avgTemp",
+              "displayName": "Average Temperature",
+              "schema": "double"
+            },
+            {
+              "name": "startTime",
+              "displayName": "Start Time",
+              "schema": "dateTime"
+            },
+            {
+              "name": "endTime",
+              "displayName": "End Time",
+              "schema": "dateTime"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/dtmi/espressif/sensorhumid-2.json
+++ b/dtmi/espressif/sensorhumid-2.json
@@ -1,0 +1,19 @@
+{
+  "@context": "dtmi:dtdl:context;2",
+  "@id": "dtmi:Espressif:SensorHumid;2",
+  "@type": "Interface",
+  "displayName": "SensorHumid",
+  "description": "Current SensorHumid on the device is HTS221.",
+  "contents": [
+    {
+      "@type": [
+        "Telemetry",
+        "RelativeHumidity"
+      ],
+      "name": "SensorHumid",
+      "displayName": "SensorHumid",
+      "schema": "double",
+      "unit": "percent"
+    }
+  ]
+}

--- a/dtmi/espressif/sensorlight-1.json
+++ b/dtmi/espressif/sensorlight-1.json
@@ -1,0 +1,89 @@
+{
+  "@context": "dtmi:dtdl:context;2",
+  "@id": "dtmi:Espressif:SensorLight;1",
+  "@type": "Interface",
+  "displayName": "SensorLight",
+  "description": "Reports current temperature and provides desired temperature control.",
+  "contents": [
+    {
+      "@type": [
+        "Telemetry",
+        "Temperature"
+      ],
+      "name": "temperature",
+      "displayName": "Temperature",
+      "description": "Temperature in degrees Celsius.",
+      "schema": "double",
+      "unit": "degreeCelsius"
+    },
+    {
+      "@type": [
+        "Property",
+        "Temperature"
+      ],
+      "name": "targetTemperature",
+      "schema": "double",
+      "displayName": "Target Temperature",
+      "description": "Allows to remotely specify the desired target temperature.",
+      "unit": "degreeCelsius",
+      "writable": true
+    },
+    {
+      "@type": [
+        "Property",
+        "Temperature"
+      ],
+      "name": "maxTempSinceLastReboot",
+      "schema": "double",
+      "unit": "degreeCelsius",
+      "displayName": "Max temperature since last reboot.",
+      "description": "Returns the max temperature since last device reboot."
+    },
+    {
+      "@type": "Command",
+      "name": "getMaxMinReport",
+      "displayName": "Get Max-Min report.",
+      "description": "This command returns the max, min and average temperature from the specified time to the current time.",
+      "request": {
+        "name": "since",
+        "displayName": "Since",
+        "description": "Period to return the max-min report.",
+        "schema": "dateTime"
+      },
+      "response": {
+        "name": "tempReport",
+        "displayName": "Temperature Report",
+        "schema": {
+          "@type": "Object",
+          "fields": [
+            {
+              "name": "maxTemp",
+              "displayName": "Max temperature",
+              "schema": "double"
+            },
+            {
+              "name": "minTemp",
+              "displayName": "Min temperature",
+              "schema": "double"
+            },
+            {
+              "name": "avgTemp",
+              "displayName": "Average Temperature",
+              "schema": "double"
+            },
+            {
+              "name": "startTime",
+              "displayName": "Start Time",
+              "schema": "dateTime"
+            },
+            {
+              "name": "endTime",
+              "displayName": "End Time",
+              "schema": "dateTime"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/dtmi/espressif/sensorlight-2.json
+++ b/dtmi/espressif/sensorlight-2.json
@@ -1,0 +1,19 @@
+{
+  "@context": "dtmi:dtdl:context;2",
+  "@id": "dtmi:Espressif:SensorLight;2",
+  "@type": "Interface",
+  "displayName": "SensorLight",
+  "description": "Current pressure on the device is BH1750FVI",
+  "contents": [
+    {
+      "@type": [
+        "Telemetry",
+        "Illuminance"
+      ],
+      "name": "SensorLight",
+      "displayName": "SensorLight",
+      "schema": "double",
+      "unit": "lux"
+    }
+  ]
+}

--- a/dtmi/espressif/sensormagnetx-1.json
+++ b/dtmi/espressif/sensormagnetx-1.json
@@ -1,0 +1,89 @@
+{
+  "@context": "dtmi:dtdl:context;2",
+  "@id": "dtmi:Espressif:SensorMagnetX;1",
+  "@type": "Interface",
+  "displayName": "SensorMagnetX",
+  "description": "Reports current temperature and provides desired temperature control.",
+  "contents": [
+    {
+      "@type": [
+        "Telemetry",
+        "Temperature"
+      ],
+      "name": "temperature",
+      "displayName": "Temperature",
+      "description": "Temperature in degrees Celsius.",
+      "schema": "double",
+      "unit": "degreeCelsius"
+    },
+    {
+      "@type": [
+        "Property",
+        "Temperature"
+      ],
+      "name": "targetTemperature",
+      "schema": "double",
+      "displayName": "Target Temperature",
+      "description": "Allows to remotely specify the desired target temperature.",
+      "unit": "degreeCelsius",
+      "writable": true
+    },
+    {
+      "@type": [
+        "Property",
+        "Temperature"
+      ],
+      "name": "maxTempSinceLastReboot",
+      "schema": "double",
+      "unit": "degreeCelsius",
+      "displayName": "Max temperature since last reboot.",
+      "description": "Returns the max temperature since last device reboot."
+    },
+    {
+      "@type": "Command",
+      "name": "getMaxMinReport",
+      "displayName": "Get Max-Min report.",
+      "description": "This command returns the max, min and average temperature from the specified time to the current time.",
+      "request": {
+        "name": "since",
+        "displayName": "Since",
+        "description": "Period to return the max-min report.",
+        "schema": "dateTime"
+      },
+      "response": {
+        "name": "tempReport",
+        "displayName": "Temperature Report",
+        "schema": {
+          "@type": "Object",
+          "fields": [
+            {
+              "name": "maxTemp",
+              "displayName": "Max temperature",
+              "schema": "double"
+            },
+            {
+              "name": "minTemp",
+              "displayName": "Min temperature",
+              "schema": "double"
+            },
+            {
+              "name": "avgTemp",
+              "displayName": "Average Temperature",
+              "schema": "double"
+            },
+            {
+              "name": "startTime",
+              "displayName": "Start Time",
+              "schema": "dateTime"
+            },
+            {
+              "name": "endTime",
+              "displayName": "End Time",
+              "schema": "dateTime"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/dtmi/espressif/sensormagnetx-2.json
+++ b/dtmi/espressif/sensormagnetx-2.json
@@ -1,0 +1,19 @@
+{
+  "@context": "dtmi:dtdl:context;2",
+  "@id": "dtmi:Espressif:SensorMagnetX;2",
+  "@type": "Interface",
+  "displayName": "SensorMagnetX",
+  "description": "Current MagnetX on the device is MPU6050",
+  "contents": [
+    {
+      "@type": [
+        "Telemetry",
+        "MagneticInduction"
+      ],
+      "name": "SensorMagnetX",
+      "displayName": "SensorMagnetX",
+      "schema": "double",
+      "unit": "tesla"
+    }
+  ]
+}

--- a/dtmi/espressif/sensormagnety-1.json
+++ b/dtmi/espressif/sensormagnety-1.json
@@ -1,0 +1,89 @@
+{
+  "@context": "dtmi:dtdl:context;2",
+  "@id": "dtmi:Espressif:SensorMagnetY;1",
+  "@type": "Interface",
+  "displayName": "SensorMagnetY",
+  "description": "Reports current temperature and provides desired temperature control.",
+  "contents": [
+    {
+      "@type": [
+        "Telemetry",
+        "Temperature"
+      ],
+      "name": "temperature",
+      "displayName": "Temperature",
+      "description": "Temperature in degrees Celsius.",
+      "schema": "double",
+      "unit": "degreeCelsius"
+    },
+    {
+      "@type": [
+        "Property",
+        "Temperature"
+      ],
+      "name": "targetTemperature",
+      "schema": "double",
+      "displayName": "Target Temperature",
+      "description": "Allows to remotely specify the desired target temperature.",
+      "unit": "degreeCelsius",
+      "writable": true
+    },
+    {
+      "@type": [
+        "Property",
+        "Temperature"
+      ],
+      "name": "maxTempSinceLastReboot",
+      "schema": "double",
+      "unit": "degreeCelsius",
+      "displayName": "Max temperature since last reboot.",
+      "description": "Returns the max temperature since last device reboot."
+    },
+    {
+      "@type": "Command",
+      "name": "getMaxMinReport",
+      "displayName": "Get Max-Min report.",
+      "description": "This command returns the max, min and average temperature from the specified time to the current time.",
+      "request": {
+        "name": "since",
+        "displayName": "Since",
+        "description": "Period to return the max-min report.",
+        "schema": "dateTime"
+      },
+      "response": {
+        "name": "tempReport",
+        "displayName": "Temperature Report",
+        "schema": {
+          "@type": "Object",
+          "fields": [
+            {
+              "name": "maxTemp",
+              "displayName": "Max temperature",
+              "schema": "double"
+            },
+            {
+              "name": "minTemp",
+              "displayName": "Min temperature",
+              "schema": "double"
+            },
+            {
+              "name": "avgTemp",
+              "displayName": "Average Temperature",
+              "schema": "double"
+            },
+            {
+              "name": "startTime",
+              "displayName": "Start Time",
+              "schema": "dateTime"
+            },
+            {
+              "name": "endTime",
+              "displayName": "End Time",
+              "schema": "dateTime"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/dtmi/espressif/sensormagnety-2.json
+++ b/dtmi/espressif/sensormagnety-2.json
@@ -1,0 +1,19 @@
+{
+  "@context": "dtmi:dtdl:context;2",
+  "@id": "dtmi:Espressif:SensorMagnetY;2",
+  "@type": "Interface",
+  "displayName": "SensorMagnetY",
+  "description": "Current MagnetY on the device is MPU6050",
+  "contents": [
+    {
+      "@type": [
+        "Telemetry",
+        "MagneticInduction"
+      ],
+      "name": "SensorMagnetY",
+      "displayName": "SensorMagnetY",
+      "schema": "double",
+      "unit": "tesla"
+    }
+  ]
+}

--- a/dtmi/espressif/sensormagnetz-1.json
+++ b/dtmi/espressif/sensormagnetz-1.json
@@ -1,0 +1,89 @@
+{
+  "@context": "dtmi:dtdl:context;2",
+  "@id": "dtmi:Espressif:SensorMagnetZ;1",
+  "@type": "Interface",
+  "displayName": "SensorMagnetZ",
+  "description": "Reports current temperature and provides desired temperature control.",
+  "contents": [
+    {
+      "@type": [
+        "Telemetry",
+        "Temperature"
+      ],
+      "name": "temperature",
+      "displayName": "Temperature",
+      "description": "Temperature in degrees Celsius.",
+      "schema": "double",
+      "unit": "degreeCelsius"
+    },
+    {
+      "@type": [
+        "Property",
+        "Temperature"
+      ],
+      "name": "targetTemperature",
+      "schema": "double",
+      "displayName": "Target Temperature",
+      "description": "Allows to remotely specify the desired target temperature.",
+      "unit": "degreeCelsius",
+      "writable": true
+    },
+    {
+      "@type": [
+        "Property",
+        "Temperature"
+      ],
+      "name": "maxTempSinceLastReboot",
+      "schema": "double",
+      "unit": "degreeCelsius",
+      "displayName": "Max temperature since last reboot.",
+      "description": "Returns the max temperature since last device reboot."
+    },
+    {
+      "@type": "Command",
+      "name": "getMaxMinReport",
+      "displayName": "Get Max-Min report.",
+      "description": "This command returns the max, min and average temperature from the specified time to the current time.",
+      "request": {
+        "name": "since",
+        "displayName": "Since",
+        "description": "Period to return the max-min report.",
+        "schema": "dateTime"
+      },
+      "response": {
+        "name": "tempReport",
+        "displayName": "Temperature Report",
+        "schema": {
+          "@type": "Object",
+          "fields": [
+            {
+              "name": "maxTemp",
+              "displayName": "Max temperature",
+              "schema": "double"
+            },
+            {
+              "name": "minTemp",
+              "displayName": "Min temperature",
+              "schema": "double"
+            },
+            {
+              "name": "avgTemp",
+              "displayName": "Average Temperature",
+              "schema": "double"
+            },
+            {
+              "name": "startTime",
+              "displayName": "Start Time",
+              "schema": "dateTime"
+            },
+            {
+              "name": "endTime",
+              "displayName": "End Time",
+              "schema": "dateTime"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/dtmi/espressif/sensormagnetz-2.json
+++ b/dtmi/espressif/sensormagnetz-2.json
@@ -1,0 +1,19 @@
+{
+  "@context": "dtmi:dtdl:context;2",
+  "@id": "dtmi:Espressif:SensorMagnetZ;2",
+  "@type": "Interface",
+  "displayName": "SensorMagnetZ",
+  "description": "Current MagnetZ on the device is MPU6050",
+  "contents": [
+    {
+      "@type": [
+        "Telemetry",
+        "MagneticInduction"
+      ],
+      "name": "SensorMagnetZ",
+      "displayName": "SensorMagnetZ",
+      "schema": "double",
+      "unit": "tesla"
+    }
+  ]
+}

--- a/dtmi/espressif/sensorpitch-1.json
+++ b/dtmi/espressif/sensorpitch-1.json
@@ -1,0 +1,89 @@
+{
+  "@context": "dtmi:dtdl:context;2",
+  "@id": "dtmi:Espressif:SensorPitch;1",
+  "@type": "Interface",
+  "displayName": "SensorPitch",
+  "description": "Reports current temperature and provides desired temperature control.",
+  "contents": [
+    {
+      "@type": [
+        "Telemetry",
+        "Temperature"
+      ],
+      "name": "temperature",
+      "displayName": "Temperature",
+      "description": "Temperature in degrees Celsius.",
+      "schema": "double",
+      "unit": "degreeCelsius"
+    },
+    {
+      "@type": [
+        "Property",
+        "Temperature"
+      ],
+      "name": "targetTemperature",
+      "schema": "double",
+      "displayName": "Target Temperature",
+      "description": "Allows to remotely specify the desired target temperature.",
+      "unit": "degreeCelsius",
+      "writable": true
+    },
+    {
+      "@type": [
+        "Property",
+        "Temperature"
+      ],
+      "name": "maxTempSinceLastReboot",
+      "schema": "double",
+      "unit": "degreeCelsius",
+      "displayName": "Max temperature since last reboot.",
+      "description": "Returns the max temperature since last device reboot."
+    },
+    {
+      "@type": "Command",
+      "name": "getMaxMinReport",
+      "displayName": "Get Max-Min report.",
+      "description": "This command returns the max, min and average temperature from the specified time to the current time.",
+      "request": {
+        "name": "since",
+        "displayName": "Since",
+        "description": "Period to return the max-min report.",
+        "schema": "dateTime"
+      },
+      "response": {
+        "name": "tempReport",
+        "displayName": "Temperature Report",
+        "schema": {
+          "@type": "Object",
+          "fields": [
+            {
+              "name": "maxTemp",
+              "displayName": "Max temperature",
+              "schema": "double"
+            },
+            {
+              "name": "minTemp",
+              "displayName": "Min temperature",
+              "schema": "double"
+            },
+            {
+              "name": "avgTemp",
+              "displayName": "Average Temperature",
+              "schema": "double"
+            },
+            {
+              "name": "startTime",
+              "displayName": "Start Time",
+              "schema": "dateTime"
+            },
+            {
+              "name": "endTime",
+              "displayName": "End Time",
+              "schema": "dateTime"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/dtmi/espressif/sensorpitch-2.json
+++ b/dtmi/espressif/sensorpitch-2.json
@@ -1,0 +1,19 @@
+{
+  "@context": "dtmi:dtdl:context;2",
+  "@id": "dtmi:Espressif:SensorPitch;2",
+  "@type": "Interface",
+  "displayName": "SensorPitch",
+  "description": "Current pitch on the device",
+  "contents": [
+    {
+      "@type": [
+        "Telemetry",
+        "Angle"
+      ],
+      "name": "SensorPitch",
+      "displayName": "SensorPitch",
+      "schema": "double",
+      "unit": "degreeOfArc"
+    }
+  ]
+}

--- a/dtmi/espressif/sensorpressure-1.json
+++ b/dtmi/espressif/sensorpressure-1.json
@@ -1,0 +1,89 @@
+{
+  "@context": "dtmi:dtdl:context;2",
+  "@id": "dtmi:Espressif:SensorPressure;1",
+  "@type": "Interface",
+  "displayName": "SensorPressure",
+  "description": "Reports current temperature and provides desired temperature control.",
+  "contents": [
+    {
+      "@type": [
+        "Telemetry",
+        "Temperature"
+      ],
+      "name": "temperature",
+      "displayName": "Temperature",
+      "description": "Temperature in degrees Celsius.",
+      "schema": "double",
+      "unit": "degreeCelsius"
+    },
+    {
+      "@type": [
+        "Property",
+        "Temperature"
+      ],
+      "name": "targetTemperature",
+      "schema": "double",
+      "displayName": "Target Temperature",
+      "description": "Allows to remotely specify the desired target temperature.",
+      "unit": "degreeCelsius",
+      "writable": true
+    },
+    {
+      "@type": [
+        "Property",
+        "Temperature"
+      ],
+      "name": "maxTempSinceLastReboot",
+      "schema": "double",
+      "unit": "degreeCelsius",
+      "displayName": "Max temperature since last reboot.",
+      "description": "Returns the max temperature since last device reboot."
+    },
+    {
+      "@type": "Command",
+      "name": "getMaxMinReport",
+      "displayName": "Get Max-Min report.",
+      "description": "This command returns the max, min and average temperature from the specified time to the current time.",
+      "request": {
+        "name": "since",
+        "displayName": "Since",
+        "description": "Period to return the max-min report.",
+        "schema": "dateTime"
+      },
+      "response": {
+        "name": "tempReport",
+        "displayName": "Temperature Report",
+        "schema": {
+          "@type": "Object",
+          "fields": [
+            {
+              "name": "maxTemp",
+              "displayName": "Max temperature",
+              "schema": "double"
+            },
+            {
+              "name": "minTemp",
+              "displayName": "Min temperature",
+              "schema": "double"
+            },
+            {
+              "name": "avgTemp",
+              "displayName": "Average Temperature",
+              "schema": "double"
+            },
+            {
+              "name": "startTime",
+              "displayName": "Start Time",
+              "schema": "dateTime"
+            },
+            {
+              "name": "endTime",
+              "displayName": "End Time",
+              "schema": "dateTime"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/dtmi/espressif/sensorpressure-2.json
+++ b/dtmi/espressif/sensorpressure-2.json
@@ -1,0 +1,19 @@
+{
+  "@context": "dtmi:dtdl:context;2",
+  "@id": "dtmi:Espressif:SensorPressure;2",
+  "@type": "Interface",
+  "displayName": "SensorPressure",
+  "description": "Current pressure on the device is FBM320",
+  "contents": [
+    {
+      "@type": [
+        "Telemetry",
+        "Pressure"
+      ],
+      "name": "SensorPressure",
+      "displayName": "SensorPressure",
+      "schema": "double",
+      "unit": "kilopascal"
+    }
+  ]
+}

--- a/dtmi/espressif/sensorroll-1.json
+++ b/dtmi/espressif/sensorroll-1.json
@@ -1,0 +1,89 @@
+{
+  "@context": "dtmi:dtdl:context;2",
+  "@id": "dtmi:Espressif:SensorRoll;1",
+  "@type": "Interface",
+  "displayName": "SensorRoll",
+  "description": "Reports current temperature and provides desired temperature control.",
+  "contents": [
+    {
+      "@type": [
+        "Telemetry",
+        "Temperature"
+      ],
+      "name": "temperature",
+      "displayName": "Temperature",
+      "description": "Temperature in degrees Celsius.",
+      "schema": "double",
+      "unit": "degreeCelsius"
+    },
+    {
+      "@type": [
+        "Property",
+        "Temperature"
+      ],
+      "name": "targetTemperature",
+      "schema": "double",
+      "displayName": "Target Temperature",
+      "description": "Allows to remotely specify the desired target temperature.",
+      "unit": "degreeCelsius",
+      "writable": true
+    },
+    {
+      "@type": [
+        "Property",
+        "Temperature"
+      ],
+      "name": "maxTempSinceLastReboot",
+      "schema": "double",
+      "unit": "degreeCelsius",
+      "displayName": "Max temperature since last reboot.",
+      "description": "Returns the max temperature since last device reboot."
+    },
+    {
+      "@type": "Command",
+      "name": "getMaxMinReport",
+      "displayName": "Get Max-Min report.",
+      "description": "This command returns the max, min and average temperature from the specified time to the current time.",
+      "request": {
+        "name": "since",
+        "displayName": "Since",
+        "description": "Period to return the max-min report.",
+        "schema": "dateTime"
+      },
+      "response": {
+        "name": "tempReport",
+        "displayName": "Temperature Report",
+        "schema": {
+          "@type": "Object",
+          "fields": [
+            {
+              "name": "maxTemp",
+              "displayName": "Max temperature",
+              "schema": "double"
+            },
+            {
+              "name": "minTemp",
+              "displayName": "Min temperature",
+              "schema": "double"
+            },
+            {
+              "name": "avgTemp",
+              "displayName": "Average Temperature",
+              "schema": "double"
+            },
+            {
+              "name": "startTime",
+              "displayName": "Start Time",
+              "schema": "dateTime"
+            },
+            {
+              "name": "endTime",
+              "displayName": "End Time",
+              "schema": "dateTime"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/dtmi/espressif/sensorroll-2.json
+++ b/dtmi/espressif/sensorroll-2.json
@@ -1,0 +1,19 @@
+{
+  "@context": "dtmi:dtdl:context;2",
+  "@id": "dtmi:Espressif:SensorRoll;2",
+  "@type": "Interface",
+  "displayName": "SensorRoll",
+  "description": "Current Roll on the device",
+  "contents": [
+    {
+      "@type": [
+        "Telemetry",
+        "Angle"
+      ],
+      "name": "SensorRoll",
+      "displayName": "SensorRoll",
+      "schema": "double",
+      "unit": "degreeOfArc"
+    }
+  ]
+}

--- a/dtmi/espressif/sensortemp-1.json
+++ b/dtmi/espressif/sensortemp-1.json
@@ -1,0 +1,89 @@
+{
+  "@context": "dtmi:dtdl:context;2",
+  "@id": "dtmi:Espressif:SensorTemp;1",
+  "@type": "Interface",
+  "displayName": "SensorTemp",
+  "description": "Reports current temperature and provides desired temperature control.",
+  "contents": [
+    {
+      "@type": [
+        "Telemetry",
+        "Temperature"
+      ],
+      "name": "temperature",
+      "displayName": "Temperature",
+      "description": "Temperature in degrees Celsius.",
+      "schema": "double",
+      "unit": "degreeCelsius"
+    },
+    {
+      "@type": [
+        "Property",
+        "Temperature"
+      ],
+      "name": "targetTemperature",
+      "schema": "double",
+      "displayName": "Target Temperature",
+      "description": "Allows to remotely specify the desired target temperature.",
+      "unit": "degreeCelsius",
+      "writable": true
+    },
+    {
+      "@type": [
+        "Property",
+        "Temperature"
+      ],
+      "name": "maxTempSinceLastReboot",
+      "schema": "double",
+      "unit": "degreeCelsius",
+      "displayName": "Max temperature since last reboot.",
+      "description": "Returns the max temperature since last device reboot."
+    },
+    {
+      "@type": "Command",
+      "name": "getMaxMinReport",
+      "displayName": "Get Max-Min report.",
+      "description": "This command returns the max, min and average temperature from the specified time to the current time.",
+      "request": {
+        "name": "since",
+        "displayName": "Since",
+        "description": "Period to return the max-min report.",
+        "schema": "dateTime"
+      },
+      "response": {
+        "name": "tempReport",
+        "displayName": "Temperature Report",
+        "schema": {
+          "@type": "Object",
+          "fields": [
+            {
+              "name": "maxTemp",
+              "displayName": "Max temperature",
+              "schema": "double"
+            },
+            {
+              "name": "minTemp",
+              "displayName": "Min temperature",
+              "schema": "double"
+            },
+            {
+              "name": "avgTemp",
+              "displayName": "Average Temperature",
+              "schema": "double"
+            },
+            {
+              "name": "startTime",
+              "displayName": "Start Time",
+              "schema": "dateTime"
+            },
+            {
+              "name": "endTime",
+              "displayName": "End Time",
+              "schema": "dateTime"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/dtmi/espressif/sensortempthreshold-1.json
+++ b/dtmi/espressif/sensortempthreshold-1.json
@@ -1,0 +1,89 @@
+{
+  "@context": "dtmi:dtdl:context;2",
+  "@id": "dtmi:Espressif:SensorTempthreshold;1",
+  "@type": "Interface",
+  "displayName": "SensorTempthreshold",
+  "description": "Reports current temperature and provides desired temperature control.",
+  "contents": [
+    {
+      "@type": [
+        "Telemetry",
+        "Temperature"
+      ],
+      "name": "temperature",
+      "displayName": "Temperature",
+      "description": "Temperature in degrees Celsius.",
+      "schema": "double",
+      "unit": "degreeCelsius"
+    },
+    {
+      "@type": [
+        "Property",
+        "Temperature"
+      ],
+      "name": "targetTemperature",
+      "schema": "double",
+      "displayName": "Target Temperature",
+      "description": "Allows to remotely specify the desired target temperature.",
+      "unit": "degreeCelsius",
+      "writable": true
+    },
+    {
+      "@type": [
+        "Property",
+        "Temperature"
+      ],
+      "name": "maxTempSinceLastReboot",
+      "schema": "double",
+      "unit": "degreeCelsius",
+      "displayName": "Max temperature since last reboot.",
+      "description": "Returns the max temperature since last device reboot."
+    },
+    {
+      "@type": "Command",
+      "name": "getMaxMinReport",
+      "displayName": "Get Max-Min report.",
+      "description": "This command returns the max, min and average temperature from the specified time to the current time.",
+      "request": {
+        "name": "since",
+        "displayName": "Since",
+        "description": "Period to return the max-min report.",
+        "schema": "dateTime"
+      },
+      "response": {
+        "name": "tempReport",
+        "displayName": "Temperature Report",
+        "schema": {
+          "@type": "Object",
+          "fields": [
+            {
+              "name": "maxTemp",
+              "displayName": "Max temperature",
+              "schema": "double"
+            },
+            {
+              "name": "minTemp",
+              "displayName": "Min temperature",
+              "schema": "double"
+            },
+            {
+              "name": "avgTemp",
+              "displayName": "Average Temperature",
+              "schema": "double"
+            },
+            {
+              "name": "startTime",
+              "displayName": "Start Time",
+              "schema": "dateTime"
+            },
+            {
+              "name": "endTime",
+              "displayName": "End Time",
+              "schema": "dateTime"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/dtmi/jp/co/covia/accelerometer-2.json
+++ b/dtmi/jp/co/covia/accelerometer-2.json
@@ -1,0 +1,26 @@
+{
+  "@context": "dtmi:dtdl:context;2",
+  "@id": "dtmi:jp:co:covia:Accelerometer;2",
+  "@type": "Interface",
+  "displayName": "Accelerometer",
+  "contents": [
+    {
+      "@type": "Telemetry",
+      "name": "AccAxisX",
+      "displayName": "ACC X Axis",
+      "schema": "double"
+    },
+    {
+      "@type": "Telemetry",
+      "name": "AccAxisY",
+      "displayName": "ACC Y Axis",
+      "schema": "double"
+    },
+    {
+      "@type": "Telemetry",
+      "name": "AccAxisZ",
+      "displayName": "ACC Z Axis",
+      "schema": "double"
+    }
+  ]
+}

--- a/dtmi/jp/co/covia/actyg3-2.json
+++ b/dtmi/jp/co/covia/actyg3-2.json
@@ -1,0 +1,39 @@
+{
+  "@context": "dtmi:dtdl:context;2",
+  "@id": "dtmi:jp:co:covia:ActyG3;2",
+  "@type": "Interface",
+  "displayName": "Acty-G3",
+  "contents": [
+    {
+      "@type": "Component",
+      "name": "Accelerometer",
+      "displayName": "Accelerometer",
+      "schema": "dtmi:jp:co:covia:Accelerometer;2"
+    },
+    {
+      "@type": "Component",
+      "name": "Gyroscope",
+      "displayName": "Gyroscope",
+      "schema": "dtmi:jp:co:covia:Gyroscope;2"
+    },
+    {
+      "@type": "Component",
+      "name": "Location",
+      "displayName": "Location",
+      "schema": "dtmi:jp:co:covia:Location;2"
+    },
+    {
+      "@type": "Component",
+      "name": "RemoteControl",
+      "displayName": "RemoteControl",
+      "schema": "dtmi:jp:co:covia:RemoteControl;2"
+    },
+    {
+      "@type": "Component",
+      "name": "deviceInformation",
+      "displayName": "Device Information interface",
+      "description": "Optional interface with basic device hardware information.",
+      "schema": "dtmi:azure:DeviceManagement:DeviceInformation;1"
+    }
+  ]
+}

--- a/dtmi/jp/co/covia/gyroscope-2.json
+++ b/dtmi/jp/co/covia/gyroscope-2.json
@@ -1,0 +1,26 @@
+{
+  "@context": "dtmi:dtdl:context;2",
+  "@id": "dtmi:jp:co:covia:Gyroscope;2",
+  "@type": "Interface",
+  "displayName": "Gyroscope",
+  "contents": [
+    {
+      "@type": "Telemetry",
+      "name": "GyroscopeAxisX",
+      "displayName": "Gyroscope X Axis",
+      "schema": "double"
+    },
+    {
+      "@type": "Telemetry",
+      "name": "GyroscopeAxisY",
+      "displayName": "Gyroscope Y Axis",
+      "schema": "double"
+    },
+    {
+      "@type": "Telemetry",
+      "name": "GyroscopeAxisZ",
+      "displayName": "Gyroscope Z Axis",
+      "schema": "double"
+    }
+  ]
+}

--- a/dtmi/jp/co/covia/location-2.json
+++ b/dtmi/jp/co/covia/location-2.json
@@ -1,0 +1,20 @@
+{
+  "@context": "dtmi:dtdl:context;2",
+  "@id": "dtmi:jp:co:covia:Location;2",
+  "@type": "Interface",
+  "displayName": "Location",
+  "contents": [
+    {
+      "@type": "Telemetry",
+      "name": "Latitude",
+      "displayName": "Latitude",
+      "schema": "double"
+    },
+    {
+      "@type": "Telemetry",
+      "name": "Longitude",
+      "displayName": "Longitude",
+      "schema": "double"
+    }
+  ]
+}

--- a/dtmi/jp/co/covia/remotecontrol-1.json
+++ b/dtmi/jp/co/covia/remotecontrol-1.json
@@ -1,0 +1,14 @@
+{
+  "@context": "dtmi:dtdl:context;2",
+  "@id": "dtmi:jp:co:covia:RemoteControl;1",
+  "@type": "Interface",
+  "displayName": "RemoteControl",
+  "description": "",
+  "contents": [
+    {
+      "@type": "Command",
+      "name": "reboot",
+      "displayName": "Reboot"
+    }
+  ]
+}

--- a/dtmi/jp/co/covia/remotecontrol-2.json
+++ b/dtmi/jp/co/covia/remotecontrol-2.json
@@ -1,0 +1,13 @@
+{
+  "@context": "dtmi:dtdl:context;2",
+  "@id": "dtmi:jp:co:covia:RemoteControl;2",
+  "@type": "Interface",
+  "displayName": "RemoteControl",
+  "contents": [
+    {
+      "@type": "Command",
+      "name": "reboot",
+      "displayName": "Reboot"
+    }
+  ]
+}

--- a/dtmi/nexcom/nise50/xcare-1.json
+++ b/dtmi/nexcom/nise50/xcare-1.json
@@ -1,0 +1,79 @@
+{
+  "@context": "dtmi:dtdl:context;2",
+  "@id": "dtmi:Nexcom:Nise50:Xcare;1",
+  "@type": "Interface",
+  "displayName": "Xcare for Nise50",
+  "description": "Reports Nise50 about system information and provides desired system control.",
+  "contents": [
+    {
+      "@type": [
+        "Telemetry",
+        "Temperature"
+      ],
+      "name": "cpuTemperature",
+      "displayName": "CPU Temperature",
+      "description": "CPU Temperature in degrees Celsius.",
+      "schema": "double",
+      "unit": "degreeCelsius"
+    },
+    {
+      "@type": [
+        "Telemetry",
+        "Temperature"
+      ],
+      "name": "sysTemperature",
+      "displayName": "SYS Temperature",
+      "description": "SYS Temperature in degrees Celsius.",
+      "schema": "double",
+      "unit": "degreeCelsius"
+    },
+    {
+      "@type": "Property",
+      "name": "modelname",
+      "displayName": "Model Name",
+      "description": "The Model Name of Board",
+      "schema": "string"
+    },
+    {
+      "@type": "Property",
+      "name": "GPIO",
+      "displayName": "GPIO",
+      "description": "The Board GPIO",
+      "schema": "integer"
+    },
+    {
+      "@type": [
+        "Property",
+        "DataSize"
+      ],
+      "name": "workingSet",
+      "displayName": "Working Set",
+      "description": "Current working set of the device memory in KiB.",
+      "schema": "double",
+      "unit": "kibibyte"
+    },
+    {
+      "@type": [
+        "Property",
+        "GPIO"
+      ],
+      "name": "targetGPIO",
+      "schema": "integer",
+      "displayName": "Target GPIO",
+      "description": "Allows to remotely specify the desired target GPIO.",
+      "writable": true
+    },
+    {
+      "@type": "Command",
+      "name": "reboot",
+      "displayName": "Reboot",
+      "description": "Reboots the device after waiting the number of seconds specified.",
+      "request": {
+        "name": "delay",
+        "displayName": "Delay",
+        "description": "Number of seconds to wait before rebooting the device.",
+        "schema": "integer"
+      }
+    }
+  ]
+}

--- a/dtmi/osconfig/commandrunner-1.json
+++ b/dtmi/osconfig/commandrunner-1.json
@@ -1,0 +1,107 @@
+{
+  "@context": "dtmi:dtdl:context;2",
+  "@id": "dtmi:osconfig:commandrunner;1",
+  "@type": "Interface",
+  "displayName": "Command Runner",
+  "description": "Provides functionality to remotely run commands on the device",
+  "contents": [
+    {
+      "@type": "Property",
+      "name": "CommandStatus",
+      "schema": {
+        "@type": "Object",
+        "fields": [
+          {
+            "name": "CommandId",
+            "schema": "string"
+          },
+          {
+            "name": "ResultCode",
+            "schema": "integer"
+          },
+          {
+            "name": "ExtendedResultCode",
+            "schema": "integer"
+          },
+          {
+            "name": "TextResult",
+            "schema": "string"
+          },
+          {
+            "name": "CurrentState",
+            "schema": {
+              "@type": "Enum",
+              "valueSchema": "integer",
+              "enumValues": [
+                {
+                  "name": "Unknown",
+                  "enumValue": 0
+                },
+                {
+                  "name": "Running",
+                  "enumValue": 1
+                },
+                {
+                  "name": "Succeeded",
+                  "enumValue": 2
+                },
+                {
+                  "name": "Failed",
+                  "enumValue": 3
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "writable": false
+    },
+    {
+      "@type": "Property",
+      "name": "CommandArguments",
+      "schema": {
+        "@type": "Object",
+        "fields": [
+          {
+            "name": "CommandId",
+            "schema": "string"
+          },
+          {
+            "name": "Arguments",
+            "schema": "string"
+          },
+          {
+            "name": "Action",
+            "schema": {
+              "@type": "Enum",
+              "valueSchema": "integer",
+              "enumValues": [
+                {
+                  "name": "None",
+                  "enumValue": 0
+                },
+                {
+                  "name": "Reboot",
+                  "enumValue": 1
+                },
+                {
+                  "name": "Shutdown",
+                  "enumValue": 2
+                },
+                {
+                  "name": "RunCommand",
+                  "enumValue": 3
+                },
+                {
+                  "name": "RefreshCommandStatus",
+                  "enumValue": 4
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "writable": true
+    }
+  ]
+}

--- a/dtmi/osconfig/deviceosconfiguration-1.json
+++ b/dtmi/osconfig/deviceosconfiguration-1.json
@@ -1,0 +1,18 @@
+{
+  "@context": "dtmi:dtdl:context;2",
+  "@id": "dtmi:osconfig:deviceosconfiguration;1",
+  "@type": "Interface",
+  "displayName": "Device OS Configuration",
+  "contents": [
+    {
+      "schema": "dtmi:osconfig:settings;1",
+      "@type": "Component",
+      "name": "Settings"
+    },
+    {
+      "schema": "dtmi:osconfig:commandrunner;1",
+      "@type": "Component",
+      "name": "CommandRunner"
+    }
+  ]
+}

--- a/dtmi/osconfig/settings-1.json
+++ b/dtmi/osconfig/settings-1.json
@@ -1,0 +1,79 @@
+{
+  "@context": "dtmi:dtdl:context;2",
+  "@id": "dtmi:osconfig:settings;1",
+  "@type": "Interface",
+  "displayName": "Settings",
+  "description": "Provides functionality to remotely configure other settings on the device",
+  "contents": [
+    {
+      "@type": "Property",
+      "name": "DeviceHealthTelemetryConfiguration",
+      "schema": {
+        "@type": "Enum",
+        "valueSchema": "integer",
+        "enumValues": [
+          {
+            "name": "None",
+            "enumValue": 0
+          },
+          {
+            "name": "Required",
+            "enumValue": 1
+          },
+          {
+            "name": "Optional",
+            "enumValue": 2
+          }
+        ]
+      },
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "DeliveryOptimizationPolicies",
+      "schema": {
+        "@type": "Object",
+        "fields": [
+          {
+            "name": "PercentageDownloadThrottle",
+            "schema": "integer"
+          },
+          {
+            "name": "CacheHostSource",
+            "schema": {
+              "@type": "Enum",
+              "valueSchema": "integer",
+              "enumValues": [
+                {
+                  "name": "None",
+                  "enumValue": 0
+                },
+                {
+                  "name": "AzureDeviceUpdate",
+                  "enumValue": 1
+                },
+                {
+                  "name": "DeviceDiscoveryService",
+                  "enumValue": 2
+                },
+                {
+                  "name": "DhcpServerCustomOptionId235",
+                  "enumValue": 3
+                }
+              ]
+            }
+          },
+          {
+            "name": "CacheHost",
+            "schema": "string"
+          },
+          {
+            "name": "CacheHostFallback",
+            "schema": "integer"
+          }
+        ]
+      },
+      "writable": true
+    }
+  ]
+}

--- a/dtmi/seeedkk/wioterminal/wioterminal_aziot_example-1.json
+++ b/dtmi/seeedkk/wioterminal/wioterminal_aziot_example-1.json
@@ -1,0 +1,36 @@
+{
+  "@id": "dtmi:seeedkk:wioterminal:wioterminal_aziot_example;1",
+  "@type": "Interface",
+  "@context": "dtmi:dtdl:context;2",
+  "displayName": "Seeed Wio Terminal",
+  "contents": [
+    {
+      "@type": "Telemetry",
+      "name": "accelX",
+      "displayName": "Acceleration X",
+      "schema": "double"
+    },
+    {
+      "@type": "Telemetry",
+      "name": "accelY",
+      "displayName": "Acceleration Y",
+      "schema": "double"
+    },
+    {
+      "@type": "Telemetry",
+      "name": "accelZ",
+      "displayName": "Acceleration Z",
+      "schema": "double"
+    },
+    {
+      "@type": "Command",
+      "name": "ringBuzzer",
+      "displayName": "Ring buzzer",
+      "request": {
+        "name": "duration",
+        "displayName": "Duration",
+        "schema": "integer"
+      }
+    }
+  ]
+}

--- a/dtmi/via/driverecorder-2.json
+++ b/dtmi/via/driverecorder-2.json
@@ -1,0 +1,105 @@
+{
+  "@context": "dtmi:dtdl:context;2",
+  "@id": "dtmi:via:Driverecorder;2",
+  "@type": "Interface",
+  "displayName": "Driverecorder",
+  "description": "Reports current GPS location and system state.",
+  "contents": [
+    {
+      "@type": "Property",
+      "name": "manufacturer",
+      "schema": "string",
+      "displayName": "Manufacturer",
+      "description": "Company name of the device manufacturer. This could be the same as the name of the original equipment manufacturer (OEM). Ex. Contoso."
+    },
+    {
+      "@type": "Property",
+      "name": "model",
+      "displayName": "Device model",
+      "schema": "string",
+      "description": "Device model name or ID. Ex. Surface Book 2."
+    },
+    {
+      "@type": "Property",
+      "name": "swVersion",
+      "displayName": "Software version",
+      "schema": "string",
+      "description": "Version of the software on your device. This could be the version of your firmware. Ex. 1.3.45"
+    },
+    {
+      "@type": "Property",
+      "name": "osName",
+      "displayName": "Operating system name",
+      "schema": "string",
+      "description": "Name of the operating system on the device. Ex. Windows 10 IoT Core."
+    },
+    {
+      "@type": "Property",
+      "name": "processorArchitecture",
+      "displayName": "Processor architecture",
+      "schema": "string",
+      "description": "Architecture of the processor on the device. Ex. x64 or ARM."
+    },
+    {
+      "@type": "Property",
+      "name": "processorManufacturer",
+      "displayName": "Processor manufacturer",
+      "schema": "string",
+      "description": "Name of the manufacturer of the processor on the device. Ex. Intel."
+    },
+    {
+      "@type": "Property",
+      "name": "totalStorage",
+      "displayName": "Total storage",
+      "schema": "long",
+      "description": "Total available storage on the device in Magebytes. Ex. 1024 Magebytes."
+    },
+    {
+      "@type": "Property",
+      "name": "totalMemory",
+      "displayName": "Total memory",
+      "schema": "long",
+      "description": "Total available memory on the device in Magebytes. Ex. 256 Magebytes."
+    },
+    {
+      "@type": "Telemetry",
+      "name": "CPUUsage",
+      "displayName": "D700 CPUUsage, unit : Percentage(%)",
+      "description": "CPU current usage, unit : Percentage(%)",
+      "schema": "double"
+    },
+    {
+      "@type": "Telemetry",
+      "name": "MemoryRemaining",
+      "displayName": "D700 MemoryRemaining,unit : Kilobytes(KB)",
+      "description": "Memory current remaining,unit : Kilobytes(KB)",
+      "schema": "double"
+    },
+    {
+      "@type": "Telemetry",
+      "name": "SysAvailSpace",
+      "displayName": "D700 SysAvailSpace,unit : Kilobytes(KB)",
+      "description": "Device current free space,unit : Kilobytes(KB)",
+      "schema": "double"
+    },
+    {
+      "@type": "Telemetry",
+      "name": "GPSLocation",
+      "displayName": "D700 GPSLocation,unit : degrees",
+      "description": "Current GPS location,unit : degrees",
+      "schema": "string"
+    },
+    {
+      "@type": "Command",
+      "name": "targetReboot",
+      "displayName": "Target Reboot",
+      "description": "his command can reboot target device after input countdown number of seconds",
+      "request": {
+        "name": "countdown",
+        "displayName": "Countdown",
+        "description": "countdown number of seconds to reboot device",
+        "schema": "string"
+      }
+    }
+  ]
+}

--- a/dtmi/via/thermostat-2.json
+++ b/dtmi/via/thermostat-2.json
@@ -1,0 +1,89 @@
+{
+  "@context": "dtmi:dtdl:context;2",
+  "@id": "dtmi:via:Thermostat;2",
+  "@type": "Interface",
+  "displayName": "Thermostat",
+  "description": "Reports current temperature and provides desired temperature control.",
+  "contents": [
+    {
+      "@type": [
+        "Telemetry",
+        "Temperature"
+      ],
+      "name": "temperature",
+      "displayName": "Temperature",
+      "description": "Temperature in degrees Celsius.",
+      "schema": "double",
+      "unit": "degreeCelsius"
+    },
+    {
+      "@type": [
+        "Property",
+        "Temperature"
+      ],
+      "name": "targetTemperature",
+      "schema": "double",
+      "displayName": "Target Temperature",
+      "description": "Allows to remotely specify the desired target temperature.",
+      "unit": "degreeCelsius",
+      "writable": true
+    },
+    {
+      "@type": [
+        "Property",
+        "Temperature"
+      ],
+      "name": "maxTempSinceLastReboot",
+      "schema": "double",
+      "unit": "degreeCelsius",
+      "displayName": "Max temperature since last reboot.",
+      "description": "Returns the max temperature since last device reboot."
+    },
+    {
+      "@type": "Command",
+      "name": "getMaxMinReport",
+      "displayName": "Get Max-Min report.",
+      "description": "This command returns the max, min and average temperature from the specified time to the current time.",
+      "request": {
+        "name": "since",
+        "displayName": "Since",
+        "description": "Period to return the max-min report.",
+        "schema": "dateTime"
+      },
+      "response": {
+        "name": "tempReport",
+        "displayName": "Temperature Report",
+        "schema": {
+          "@type": "Object",
+          "fields": [
+            {
+              "name": "maxTemp",
+              "displayName": "Max temperature",
+              "schema": "double"
+            },
+            {
+              "name": "minTemp",
+              "displayName": "Min temperature",
+              "schema": "double"
+            },
+            {
+              "name": "avgTemp",
+              "displayName": "Average Temperature",
+              "schema": "double"
+            },
+            {
+              "name": "startTime",
+              "displayName": "Start Time",
+              "schema": "dateTime"
+            },
+            {
+              "name": "endTime",
+              "displayName": "End Time",
+              "schema": "dateTime"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds the interfaces available in the previous model repo

```
[
  "dtmi:via:Driverecorder;2",
  "dtmi:Nexcom:Nise50:Xcare;1",
  "dtmi:via:Thermostat;2",
  "dtmi:Advantech:EIS_D210;1",
  "dtmi:Advantech:EIS_D150;1",
  "dtmi:Advantech:MIC_77Q;1",
  "dtmi:jp:co:covia:ActyG3;2",
  "dtmi:jp:co:covia:RemoteControl;2",
  "dtmi:jp:co:covia:Location;2",
  "dtmi:jp:co:covia:Gyroscope;2",
  "dtmi:jp:co:covia:Accelerometer;2",
  "dtmi:Advantech:EPC_U2117;2",
  "dtmi:Advantech:VGA;1",
  "dtmi:Advantech:SDRAM;1",
  "dtmi:Advantech:SensorsInformation;2",
  "dtmi:Advantech:GPIO;1",
  "dtmi:Espressif:SensorController;2",
  "dtmi:Espressif:SensorRoll;2",
  "dtmi:Espressif:SensorPressure;2",
  "dtmi:Espressif:SensorPitch;2",
  "dtmi:Espressif:SensorMagnetZ;2",
  "dtmi:Espressif:SensorMagnetY;2",
  "dtmi:Espressif:SensorMagnetX;2",
  "dtmi:Espressif:SensorLight;2",
  "dtmi:Espressif:SensorHumid;2",
  "dtmi:Espressif:SensorAltitude;2",
  "dtmi:Espressif:DeviceInformation;2",
  "dtmi:Brainium:SmartEdgeAgile;1",
  "dtmi:Espressif:SensorController;1",
  "dtmi:Espressif:SensorTempthreshold;1",
  "dtmi:Espressif:SensorTemp;1",
  "dtmi:Espressif:SensorRoll;1",
  "dtmi:Espressif:SensorPressure;1",
  "dtmi:Espressif:SensorPitch;1",
  "dtmi:Espressif:SensorMagnetZ;1",
  "dtmi:Espressif:SensorMagnetY;1",
  "dtmi:Espressif:SensorMagnetX;1",
  "dtmi:Espressif:SensorLight;1",
  "dtmi:Espressif:SensorHumid;1",
  "dtmi:Espressif:SensorFanSpeed;1",
  "dtmi:Espressif:SensorAltitude;1",
  "dtmi:Espressif:DeviceInformation;1",
  "dtmi:com:Octonion:SmartEdgeAgileDevice;1",
  "dtmi:Advantech:EPC_U2117;1",
  "dtmi:jp:co:covia:RemoteControl;1",
  "dtmi:Advantech:UTC_520;2",
  "dtmi:Advantech:UTC_520;1",
  "dtmi:Advantech:SensorsInformation;1",
  "dtmi:Advantech:DeviceDetailedInformation;1",
  "dtmi:seeedkk:wioterminal:wioterminal_aziot_example;1",
  "dtmi:Allegion:LockConfig;1",
  "dtmi:osconfig:deviceosconfiguration;1",
  "dtmi:osconfig:settings;1",
  "dtmi:osconfig:commandrunner;1"
]

```