### PR TITLE
Improve WF validation. Improve PR template.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,44 +11,56 @@ The repository pipeline will ensure minimum validation of incoming DTDL models.
 
 When submitting models to the repository we ask that you provide as much of the following meta information around your models and related devices as possible. This info will be used to improve Plug and Play.
 
+:star2: Please replace the markdown comment examples with your own values.
+
 ### Company Info
 
+<!--
 > Info identifying your company (if applicable).
 
 Examples:
-
 - Company name
 - Company website
 - GitHub presence
 - Other
 
+-->
+
 ### PnP Device Info
 
+<!--
 > Info identifying your PnP device.
 
 Examples:
-
 - Product website
 - OS & Arch
 - SDK used for model implementation
 - Other
 
+-->
+
 ### Model Submission Goals
 
+<!--
 > Info related to broader PnP goals.  
 
 Examples:
-
 - Device certification
 - Presence in the [Certified Device catalog](https://devicecatalog.azure.com/)
 - IoT Central integration
 - Custom solution
 - Other
 
+-->
+
 ### Code Owners & Reserved Names
 
+<!--
 > Indicates GitHub alias entries to be added to the repo `CODEOWNERS` for the incoming model namespace. The codeowner is expected to be involved in subsequent DTDL model submissions against the same namespace.
 
-Examples:
+If no alias is specified then we assume the PR submitter is responsible for the namespace.
 
+Examples:
 - @ContosoModelNamespaceOwner 1
+
+-->

--- a/.github/workflows/push_expanded_to_storage.yml
+++ b/.github/workflows/push_expanded_to_storage.yml
@@ -31,6 +31,7 @@ jobs:
 
       - name: Expand models
         run: |
+          set -ex
           for changed_file in ${{ steps.files.outputs.added_modified }}; do
             if [[ ${changed_file} =~ ^dtmi([\/\\][a-z0-9_]+){2,}-([1-9][0-9]{0,8}).json$ ]]; then
               dmr-client export --model-file ${changed_file} --repo $PWD -o ${changed_file//.json/.expanded.json} --silent

--- a/.github/workflows/validate_models.yml
+++ b/.github/workflows/validate_models.yml
@@ -30,18 +30,21 @@ jobs:
 
       - name: Validate Models
         run: |
-          for f in  ${{ steps.files.outputs.added_modified }};
+          for f in ${{ steps.files.outputs.added_modified }};
           do
-              if [[ $f =~ ^dtmi([\/\\][a-z0-9_]+){2,}-([1-9][0-9]{0,8}).json$ ]]
+              if [[ $f =~ ^dtmi([\/\\]) ]]
               then
-                  echo "Validating: $f"
+                if [[ $f =~ ^dtmi([\/\\][a-z0-9_]+){2,}-([1-9][0-9]{0,8}).json$ ]]
+                then
                   dmr-client validate --model-file $f --repo $PWD --strict
-                  if [ $? -eq 0 ]
-                  then
-                      echo "Validation OK: $f"
-                  fi
+                else
+                  echo "::error file=$f::Invalid model placement. 
+                  Use the dmr-client import command or review the resolution convention spec: 
+                  https://github.com/Azure/iot-plugandplay-models-tools/wiki/Resolution-Convention#folder-and-file-structure"
+                  exit 1
+                fi
               else
-                echo "Skipping validation: $f"
+                echo "Skipping non-model file: $f"
               fi
           done
         shell: bash
@@ -57,7 +60,7 @@ jobs:
       - name: Reject edits to Models
         run: |
           exit_code=0
-          for f in  ${{ steps.files.outputs.modified }};
+          for f in ${{ steps.files.outputs.modified }};
           do
             if [[ $f =~ ^dtmi([\/\\][a-z0-9_]+){2,}-([1-9][0-9]{0,8}).json$ ]]
             then
@@ -79,7 +82,7 @@ jobs:
       - name: Reject renames to Models
         run: |
           exit_code=0
-          for f in  ${{ steps.files.outputs.renamed }};
+          for f in ${{ steps.files.outputs.renamed }};
           do
             if [[ $f =~ ^dtmi([\/\\][a-z0-9_]+){2,}-([1-9][0-9]{0,8}).json$ ]]
             then
@@ -101,7 +104,7 @@ jobs:
       - name: Reject deletions to Models
         run: |
           exit_code=0
-          for f in  ${{ steps.files.outputs.removed }};
+          for f in ${{ steps.files.outputs.removed }};
           do
             if [[ $f =~ ^dtmi([\/\\][a-z0-9_]+){2,}-([1-9][0-9]{0,8}).json$ ]]
             then
@@ -125,12 +128,12 @@ jobs:
           exit_code=0
           for f in  ${{ steps.files.outputs.added_modified }};
           do
-              if [[ $f =~ ^dtmi([\/\\][a-z0-9_]+){2,}-([1-9][0-9]{0,8}).json$ ]]
-              then
-                  echo "skipping DTDL file $f"
-              else
-                echo "::warning file=$f::Please review non-DTDL file changes."
-              fi
+            if [[ $f =~ ^dtmi([\/\\][a-z0-9_]+){2,}-([1-9][0-9]{0,8}).json$ ]]
+            then
+              echo "skipping DTDL file $f"
+            else
+              echo "::warning file=$f::Please review non-DTDL file changes."
+            fi
           done
           exit $exit_code
         shell: bash


### PR DESCRIPTION
This PR
- Improves the PR template format
  - Keeps example data points as comments to prevent markdown render.
  - Clarified some language.
- Ensure non-well formed model file placed in valid dtmi convention (with respect to the `dtmi/` directory) location will error
  - See [this failure](https://github.com/digimaun/iot-plugandplay-models/pull/15/checks?check_run_id=1482341487) for example
- Ensure model file placed in a non-valid dtmi convention (with respect to the `dtmi/` directory) will error.
  - See [this failure](https://github.com/digimaun/iot-plugandplay-models/pull/14/checks?check_run_id=1482333194) for example


PR Format example:

![image](https://user-images.githubusercontent.com/28658112/100798610-ba828300-33d8-11eb-8acd-dd6b6e643a7f.png)
![image](https://user-images.githubusercontent.com/28658112/100798620-be160a00-33d8-11eb-8361-b02d4b830253.png)
