### PR TITLE
Nuvoton NuMaker-IoT-M487 Interface

### DIFF
--- a/dtmi/nuvoton/numaker_iot_m487_dev-1.json
+++ b/dtmi/nuvoton/numaker_iot_m487_dev-1.json
@@ -1,0 +1,56 @@
+{
+  "@id": "dtmi:nuvoton:numaker_iot_m487_dev;1",
+  "@type": "Interface",
+  "@context": "dtmi:dtdl:context;2",
+  "displayName": "NuMaker IoT M487 Dev",
+  "contents": [
+    {
+      "@type": "Property",
+      "name": "led",
+      "displayName": "LED",
+      "description": "LED of the device.",
+      "writable": true,
+      "schema": "integer"
+    },
+    {
+      "@type": "Property",
+      "name": "button1",
+      "displayName": "Button1",
+      "description": "Button-01 of the device.",
+      "schema": "integer"
+    },    
+    {
+      "@type": "Property",
+      "name": "button2",
+      "displayName": "Button2",
+      "description": "Button-02 of the device.",
+      "schema": "integer"
+    },    
+    {
+      "@type": "Command",
+      "name": "reboot",
+      "displayName": "Reboot",
+      "description": "Reboots the device after waiting the number of seconds specified.",
+      "request": {
+        "name": "delay",
+        "displayName": "Delay",
+        "description": "Number of seconds to wait before rebooting the device.",
+        "schema": "integer"
+      }
+    },
+    {
+      "@type" : "Component",
+      "schema": "dtmi:nuvoton:sensor_bmx055;1",
+      "name": "motionSensorBMX055",
+      "displayName": "Motion Sensor BMX055",
+      "description": "Report current temperature and acceleration."
+    },
+    {
+      "@type": "Component",
+      "schema": "dtmi:azure:DeviceManagement:DeviceInformation;1",
+      "name": "deviceInformation",
+      "displayName": "Device Information interface",
+      "description": "Optional interface with basic device hardware information."
+    }    
+  ]
+}

--- a/dtmi/nuvoton/numaker_iot_m487_dev-1.json
+++ b/dtmi/nuvoton/numaker_iot_m487_dev-1.json
@@ -10,21 +10,21 @@
       "displayName": "LED",
       "description": "LED of the device.",
       "writable": true,
-      "schema": "integer"
+      "schema": "boolean"
     },
     {
-      "@type": "Property",
+      "@type": "Telemetry",
       "name": "button1",
       "displayName": "Button1",
       "description": "Button-01 of the device.",
-      "schema": "integer"
+      "schema": "boolean"
     },    
     {
-      "@type": "Property",
+      "@type": "Telemetry",
       "name": "button2",
       "displayName": "Button2",
       "description": "Button-02 of the device.",
-      "schema": "integer"
+      "schema": "boolean"
     },    
     {
       "@type": "Command",

--- a/dtmi/nuvoton/sensor_bmx055-1.json
+++ b/dtmi/nuvoton/sensor_bmx055-1.json
@@ -9,8 +9,7 @@
       "@type":  ["Telemetry", "Acceleration"],
       "name": "accelX",
       "displayName": {
-        "en": "Acceleration X",
-        "zh": "加速度 X"
+        "en": "Acceleration X"
       },
       "schema": "float",
       "unit": "gForce"
@@ -19,8 +18,7 @@
       "@type":  ["Telemetry", "Acceleration"],
       "name": "accelY",
       "displayName": {
-        "en": "Acceleration Y",
-        "zh": "加速度 Y"
+        "en": "Acceleration Y"
       },
       "schema": "float",
       "unit": "gForce"
@@ -29,8 +27,7 @@
       "@type":  ["Telemetry", "Acceleration"],
       "name": "accelZ",
       "displayName": {
-        "en": "Acceleration Z",
-        "zh": "加速度 Z"
+        "en": "Acceleration Z"
       },
       "schema": "float",
       "unit": "gForce"
@@ -39,8 +36,7 @@
       "@type":  ["Telemetry", "Temperature"],
       "name": "temperature",
       "displayName": {
-        "en": "Temperature",
-        "zh": "溫度"
+        "en": "Temperature"
       },
       "schema": "float",
       "unit": "degreeCelsius"

--- a/dtmi/nuvoton/sensor_bmx055-1.json
+++ b/dtmi/nuvoton/sensor_bmx055-1.json
@@ -1,0 +1,49 @@
+{
+  "@context": "dtmi:dtdl:context;2",
+  "@id": "dtmi:nuvoton:sensor_bmx055;1",
+  "@type": "Interface",
+  "displayName": "Motion Sensor BMX055",
+  "description": "Report current temperature and acceleration.",
+  "contents": [
+    {
+      "@type":  ["Telemetry", "Acceleration"],
+      "name": "accelX",
+      "displayName": {
+        "en": "Acceleration X",
+        "zh": "加速度 X"
+      },
+      "schema": "float",
+      "unit": "gForce"
+    },
+    {
+      "@type":  ["Telemetry", "Acceleration"],
+      "name": "accelY",
+      "displayName": {
+        "en": "Acceleration Y",
+        "zh": "加速度 Y"
+      },
+      "schema": "float",
+      "unit": "gForce"
+    },
+    {
+      "@type":  ["Telemetry", "Acceleration"],
+      "name": "accelZ",
+      "displayName": {
+        "en": "Acceleration Z",
+        "zh": "加速度 Z"
+      },
+      "schema": "float",
+      "unit": "gForce"
+    },
+    {
+      "@type":  ["Telemetry", "Temperature"],
+      "name": "temperature",
+      "displayName": {
+        "en": "Temperature",
+        "zh": "溫度"
+      },
+      "schema": "float",
+      "unit": "degreeCelsius"
+    }
+  ]
+}


### PR DESCRIPTION

### Company Info

- Company name: Nuvoton
- Company website: www.nuvoton.com
- GitHub presence: https://github.com/cyliangtw/iot-plugandplay-models


### PnP Device Info


- Product website: http://www.nuvoton.com.cn/board/numaker-iot-m487/
- OS & Arch: Mbed OS, ARM Cortex-M4
- SDK used for model implementation: Azure-C-SDK


### Model Submission Goals


- Device certification


### Test log
test-id: b9f2537a-6d07-49d9-9551-fe7e985fb355
log: attachment test log file
[iot-m487-log.txt](https://github.com/Azure/iot-plugandplay-models/files/5694321/iot-m487-log.txt)


### Code Owners & Reserved Names

@cyliangtw


