### PR TITLE
Add ADLINK-IPiSMARCPx30 model.

### DIFF
--- a/dtmi/adlink/ipismarcpx30-1.json
+++ b/dtmi/adlink/ipismarcpx30-1.json
@@ -1,0 +1,13 @@
+{
+    "@context": "dtmi:dtdl:context;2",
+    "@id": "dtmi:ADLINK:IPiSMARCPx30;1",
+    "@type": "Interface",
+    "displayName": "ADLINK-IPiSMARCPx30",
+    "contents": [
+        {
+            "@type": "Component",
+            "name": "LinuxDeviceInfo1",
+            "schema": "dtmi:Synnex:LinuxDeviceInfo;1"
+        }
+    ]
+}


### PR DESCRIPTION
### Company Info
ADLINK
https://www.adlinktech.com/en/index
<!--
> Info identifying your company (if applicable).

Examples:
- Company name
- Company website
- GitHub presence
- Other

-->

### IoT Plug and Play Device Info
I-Pi SMARC PX30
https://www.ipi.wiki/pages/i-pi-smarc-px30
<!--
> Info identifying your PnP device.

Examples:
- Product website
- OS & Arch
- SDK used for model implementation
- Other

-->

### Model Submission Goals
Device certification
Presence in the Certified Device catalog
<!--
> Info related to broader PnP goals.  

Examples:
- Device certification
- Presence in the [Certified Device catalog](https://devicecatalog.azure.com/)
- IoT Central integration
- Custom solution
- Other

-->

### Code Owners & Reserved Names

<!--
> Indicates GitHub alias entries to be added to the repo `CODEOWNERS` for the incoming model namespace. The codeowner is expected to be involved in subsequent DTDL model submissions against the same namespace.

If no alias is specified then we assume the PR submitter is responsible for the namespace.

Examples:
- @ContosoModelNamespaceOwner 1

-->
