### PR TITLE
Add ASUS-TinkerBoard model.

### DIFF
--- a/dtmi/asus/tinkerboard-1.json
+++ b/dtmi/asus/tinkerboard-1.json
@@ -1,0 +1,38 @@
+{
+    "@context": "dtmi:dtdl:context;2",
+    "@id": "dtmi:ASUS:TinkerBoard;1",
+    "@type": "Interface",
+    "displayName": "ASUS-TinkerBoard",
+    "contents": [
+        {
+            "@type": [
+              "Telemetry",
+              "Temperature"
+            ],
+            "name": "currentTempGPU",
+            "displayName": "Current Temperature (GPU)",
+            "schema": "double",
+            "unit": "degreeCelsius"
+        },
+        {
+            "@type": "Component",
+            "name": "LinuxDeviceInfo1",
+            "schema": "dtmi:Synnex:LinuxDeviceInfo;1"
+        },
+        {
+            "@type": "Component",
+            "name": "PIRsensor0",
+            "schema": "dtmi:Synnex:PIRmotion_sensor;1"
+        },
+        {
+            "@type": "Component",
+            "name": "PIRsensor1",
+            "schema": "dtmi:Synnex:PIRmotion_sensor;1"
+        },
+        {
+            "@type": "Component",
+            "name": "PIRsensor2",
+            "schema": "dtmi:Synnex:PIRmotion_sensor;1"
+        }
+    ]
+}


### PR DESCRIPTION
### Company Info
ASUS
https://www.asus.com/tw/
<!--
> Info identifying your company (if applicable).

Examples:
- Company name
- Company website
- GitHub presence
- Other

-->

### IoT Plug and Play Device Info
Tinker Board
https://www.asus.com/tw/Single-Board-Computer/Tinker-Board/
<!--
> Info identifying your PnP device.

Examples:
- Product website
- OS & Arch
- SDK used for model implementation
- Other

-->

### Model Submission Goals
Device certification
Presence in the Certified Device catalog
<!--
> Info related to broader PnP goals.  

Examples:
- Device certification
- Presence in the [Certified Device catalog](https://devicecatalog.azure.com/)
- IoT Central integration
- Custom solution
- Other

-->

### Code Owners & Reserved Names

<!--
> Indicates GitHub alias entries to be added to the repo `CODEOWNERS` for the incoming model namespace. The codeowner is expected to be involved in subsequent DTDL model submissions against the same namespace.

If no alias is specified then we assume the PR submitter is responsible for the namespace.

Examples:
- @ContosoModelNamespaceOwner 1

-->
