### PR TITLE
Add JWIPC-K065model.

### DIFF
--- a/dtmi/jwipc/k065-1.json
+++ b/dtmi/jwipc/k065-1.json
@@ -1,0 +1,13 @@
+{
+    "@context": "dtmi:dtdl:context;2",
+    "@id": "dtmi:JWIPC:K065;1",
+    "@type": "Interface",
+    "displayName": "JWIPC-K065",
+    "contents": [
+        {
+            "@type": "Component",
+            "name": "WindowsDeviceInfo1",
+            "schema": "dtmi:Synnex:WindowsDeviceInfo;1"
+        }
+    ]
+}


### PR DESCRIPTION
### Company Info
JWIPC
http://www.jwipc.com/
<!--
> Info identifying your company (if applicable).

Examples:
- Company name
- Company website
- GitHub presence
- Other

-->

### IoT Plug and Play Device Info
K065
http://www.jwipc.com/pro/p43.html
<!--
> Info identifying your PnP device.

Examples:
- Product website
- OS & Arch
- SDK used for model implementation
- Other

-->

### Model Submission Goals
Device certification
Presence in the Certified Device catalog
<!--
> Info related to broader PnP goals.  

Examples:
- Device certification
- Presence in the [Certified Device catalog](https://devicecatalog.azure.com/)
- IoT Central integration
- Custom solution
- Other

-->

### Code Owners & Reserved Names

<!--
> Indicates GitHub alias entries to be added to the repo `CODEOWNERS` for the incoming model namespace. The codeowner is expected to be involved in subsequent DTDL model submissions against the same namespace.

If no alias is specified then we assume the PR submitter is responsible for the namespace.

Examples:
- @ContosoModelNamespaceOwner 1

-->
