### PR TITLE
Add factor of ozone into sysinno Air Quality Detector

### DIFF
--- a/dtmi/sysinno/iaeris1-1.json
+++ b/dtmi/sysinno/iaeris1-1.json
@@ -1,0 +1,65 @@
+{
+    "@context": "dtmi:dtdl:context;2",
+    "@id": "dtmi:sysinno:iaeris1;1",
+    "@type": "Interface",
+    "displayName": "Azure Sphere iAeris1 Detector",
+    "description": "iAeris is a series",
+    "contents": [
+        {
+            "@type": "Telemetry",
+            "name": "HCHO",
+            "displayName": "HCHO",
+            "description": "Formaldehyde measurement from the sensor of iAeris1 averaged between telemetry post intervals, in ppm.",
+            "schema": "float"
+        },
+        {
+            "@type": "Telemetry",
+            "name": "CO2",
+            "displayName": "CO2",
+            "description": "Carbon dioxide mesurement from the sesnor of iAeris1 averaged between telemetry post intervals, in ppm.",
+            "schema": "integer"
+        },
+        {
+            "@type": "Telemetry",
+            "name": "TEMP",
+            "displayName": "Temperature",
+            "description": "Temperature measurement from the sensor of iAeris1 averaged between telemetry post intervals, in °C.",
+            "schema": "float"
+        },
+        {
+            "@type": "Telemetry",
+            "name":"RH",
+            "displayName": "RH",
+            "description": "Relative humidity measurement from the sensor of iAeris averaged between telemetry post intervals, in %.",
+            "schema": "integer"
+        },
+        {
+            "@type": "Telemetry",
+            "name": "CO",
+            "displayName": "CO",
+            "description": "Carbon monoxide mesurement from the sesnor of iAeris1 averaged between telemetry post intervals, in ppm.",
+            "schema": "integer"
+        },
+        {
+            "@type": "Telemetry",
+            "name": "PM10",
+            "displayName": "PM10",
+            "description": "Particulates with a diameter of 10 micrometres or less. It mesurement from the sesnor of iAeris1 averaged between telemetry post intervals, in ppm.",
+            "schema": "float"
+        },
+        {
+            "@type": "Telemetry",
+            "name": "PM25",
+            "displayName": "PM2.5",
+            "description": "Particulates with a diameter of 2.5 micrometres or less. It mesurement from the sesnor of iAeris1 averaged between telemetry post intervals, in ppm.",
+            "schema": "float"
+        },
+        {
+            "@type": "Telemetry",
+            "name": "TVOC",
+            "displayName": "TVOC",
+            "description": "Total volatile organic compound mesurement from the sesnor of iAeris1 averaged between telemetry post intervals, in ppm.",
+            "schema": "float"
+        }
+    ]
+}

--- a/dtmi/sysinno/iaeris1-2.json
+++ b/dtmi/sysinno/iaeris1-2.json
@@ -1,0 +1,72 @@
+{
+    "@context": "dtmi:dtdl:context;2",
+    "@id": "dtmi:sysinno:iaeris1;2",
+    "@type": "Interface",
+    "displayName": "Azure Sphere iAeris1 Detector",
+    "description": "iAeris is a series",
+    "contents": [
+        {
+            "@type": "Telemetry",
+            "name": "HCHO",
+            "displayName": "HCHO",
+            "description": "Formaldehyde measurement from the sensor of iAeris1 averaged between telemetry post intervals, in ppm.",
+            "schema": "float"
+        },
+        {
+            "@type": "Telemetry",
+            "name": "CO2",
+            "displayName": "CO2",
+            "description": "Carbon dioxide mesurement from the sesnor of iAeris1 averaged between telemetry post intervals, in ppm.",
+            "schema": "integer"
+        },
+        {
+            "@type": "Telemetry",
+            "name": "TEMP",
+            "displayName": "Temperature",
+            "description": "Temperature measurement from the sensor of iAeris1 averaged between telemetry post intervals, in °C.",
+            "schema": "float"
+        },
+        {
+            "@type": "Telemetry",
+            "name":"RH",
+            "displayName": "RH",
+            "description": "Relative humidity measurement from the sensor of iAeris averaged between telemetry post intervals, in %.",
+            "schema": "integer"
+        },
+        {
+            "@type": "Telemetry",
+            "name": "CO",
+            "displayName": "CO",
+            "description": "Carbon monoxide mesurement from the sesnor of iAeris1 averaged between telemetry post intervals, in ppm.",
+            "schema": "integer"
+        },
+        {
+            "@type": "Telemetry",
+            "name": "PM10",
+            "displayName": "PM10",
+            "description": "Particulates with a diameter of 10 micrometres or less. It mesurement from the sesnor of iAeris1 averaged between telemetry post intervals, in ppm.",
+            "schema": "float"
+        },
+        {
+            "@type": "Telemetry",
+            "name": "PM25",
+            "displayName": "PM2.5",
+            "description": "Particulates with a diameter of 2.5 micrometres or less. It mesurement from the sesnor of iAeris1 averaged between telemetry post intervals, in ppm.",
+            "schema": "float"
+        },
+        {
+            "@type": "Telemetry",
+            "name": "TVOC",
+            "displayName": "TVOC",
+            "description": "Total volatile organic compound mesurement from the sesnor of iAeris1 averaged between telemetry post intervals, in ppm.",
+            "schema": "float"
+        },
+        {
+            "@type": "Telemetry",
+            "name": "O3",
+            "displayName": "O3",
+            "description": "Total Ozone mesurement from the sesnor of iAeris1 averaged between telemetry post intervals, in ppm.",
+            "schema": "float"
+       }
+    ]
+}


### PR DESCRIPTION
### Company Info

- Company name: Sysinno Technology Inc.
- Company website : [https://www.sysinnotec.com/ehomepage](https://www.sysinnotec.com/ehomepage)

### IoT Plug and Play Device Info

- Product pdf : [iAeris Indoor Air Quality Detector PDF](https://ac1f3ec5-3a86-4c35-9d2e-c0d4f323d127.filesusr.com/ugd/2f33a0_a7abe4d205c24ef995e6d5b4cc446ab6.pdf)
- MCU: Azure sphere

### Model Submission Goals

- Device certification
- Presence in the [Certified Device catalog](https://devicecatalog.azure.com/)
- Custom solution

### Code Owners & Reserved Names

@Lin-YenYu-sysinno
