### PR TITLE
Add QBiX-Pro-WHLA8265H-C2 model

### DIFF
--- a/dtmi/gigaipc/qbixprowhla8265hc2-1.json
+++ b/dtmi/gigaipc/qbixprowhla8265hc2-1.json
@@ -1,0 +1,13 @@
+{
+    "@context": "dtmi:dtdl:context;2",
+    "@id": "dtmi:GIGAIPC:QBiXProWHLA8265HC2;1",
+    "@type": "Interface",
+    "displayName": "GIGAIPC-QBiXProWHLA8265HC2",
+    "contents": [
+        {
+            "@type": "Component",
+            "name": "WindowsDeviceInfo1",
+            "schema": "dtmi:Synnex:WindowsDeviceInfo;1"
+        }
+    ]
+}


### PR DESCRIPTION
### Company Info
GIGAIPC
http://www.gigaipc.com/
<!--
> Info identifying your company (if applicable).

Examples:
- Company name
- Company website
- GitHub presence
- Other

-->

### IoT Plug and Play Device Info
QBiX-Pro-WHLA8265H-C2
https://www.gigaipc.online/innodisk-qbix-pro
<!--
> Info identifying your PnP device.

Examples:
- Product website
- OS & Arch
- SDK used for model implementation
- Other

-->

### Model Submission Goals
Device certification
Presence in the Certified Device catalog
<!--
> Info related to broader PnP goals.  

Examples:
- Device certification
- Presence in the [Certified Device catalog](https://devicecatalog.azure.com/)
- IoT Central integration
- Custom solution
- Other

-->

### Code Owners & Reserved Names

<!--
> Indicates GitHub alias entries to be added to the repo `CODEOWNERS` for the incoming model namespace. The codeowner is expected to be involved in subsequent DTDL model submissions against the same namespace.

If no alias is specified then we assume the PR submitter is responsible for the namespace.

Examples:
- @ContosoModelNamespaceOwner 1

-->
