### PR TITLE
Add Himax_AIoT_NB_G1 model

### DIFF
--- a/dtmi/himax/Himax_AIoT_NB_G1.json
+++ b/dtmi/himax/Himax_AIoT_NB_G1.json
@@ -1,0 +1,52 @@
+{
+  "@id": "dtmi:himax:weiplus;2",
+  "@context": "dtmi:dtdl:context;2",
+  "@type": "Interface",
+  "contents": [
+    {
+      "@type": "Telemetry",
+      "displayName": {
+        "en": "human"
+      },
+      "description": "Current detected human number.",
+      "name": "human",
+      "schema": "integer"
+    },
+    {
+      "@type": "Telemetry",
+      "displayName": {
+        "en": "det_box_x"
+      },
+      "description": "bounding box x-axis for detected human.",
+      "name": "det_box_x",
+      "schema": "integer"
+    },
+    {
+      "@type": "Telemetry",
+      "displayName": {
+        "en": "det_box_y"
+      },
+      "description": "bounding box y-axis for detected human.",
+      "name": "det_box_y",
+      "schema": "integer"
+    },
+    {
+      "@type": "Telemetry",
+      "displayName": {
+        "en": "det_box_width"
+      },
+      "description": "bounding box width for detected human.",
+      "name": "det_box_width",
+      "schema": "integer"
+    },
+    {
+      "@type": "Telemetry",
+      "displayName": {
+        "en": "det_box_height"
+      },
+      "description": "bounding box height for detected human.",
+      "name": "det_box_height",
+      "schema": "integer"
+    }
+  ]
+}


### PR DESCRIPTION
### Thank you for contributing to the Azure IoT Plug and Play Models repository

This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

The repository pipeline will ensure minimum validation of incoming DTDL models.  

- PR validation steps are described in the tools [Wiki](https://github.com/Azure/iot-plugandplay-models-tools/wiki/Validation-Pipeline#pr-validation-checks).
- The same validation can be run locally via the [dmr-client](https://github.com/Azure/iot-plugandplay-models-tools/tree/dev/clients/dotnet#device-model-repository-client) CLI.

## Requested info template for model(s) submission

When submitting models to the repository we ask that you provide as much of the following meta information around your models and related devices as possible. This info will be used to improve Plug and Play.

:star2: Please replace the markdown comment examples with your own values.

### Company Info
[Himax Technologies, Inc](https://www.himax.com.tw/)
<!--
> Info identifying your company (if applicable).

Examples:
- Company name
- Company website
- GitHub presence
- Other

-->

### IoT Plug and Play Device Info
[WE-I Plus](https://devicecatalog.azure.com/devices/0a4dcf92-5fe9-4156-9699-ba9e5c15e03e)
<!--
> Info identifying your PnP device.

Examples:
- Product website
- OS & Arch
- SDK used for model implementation
- Other

-->



<!--
> Info related to broader PnP goals.  

Examples:
- Device certification
- Presence in the [Certified Device catalog](https://devicecatalog.azure.com/)
- IoT Central integration
- Custom solution
- Other

-->


<!--
> Indicates GitHub alias entries to be added to the repo `CODEOWNERS` for the incoming model namespace. The codeowner is expected to be involved in subsequent DTDL model submissions against the same namespace.

If no alias is specified then we assume the PR submitter is responsible for the namespace.

Examples:
- @ContosoModelNamespaceOwner 1

-->
