### PR TITLE
New Firewall interface for OSConfig model

### DIFF
--- a/dtmi/osconfig/deviceosconfiguration-3.json
+++ b/dtmi/osconfig/deviceosconfiguration-3.json
@@ -1,0 +1,28 @@
+{
+  "@context": "dtmi:dtdl:context;2",
+  "@id": "dtmi:osconfig:deviceosconfiguration;3",
+  "@type": "Interface",
+  "displayName": "Device OS Configuration",
+  "contents": [
+    {
+      "schema": "dtmi:osconfig:settings;1",
+      "@type": "Component",
+      "name": "Settings"
+    },
+    {
+      "schema": "dtmi:osconfig:commandrunner;1",
+      "@type": "Component",
+      "name": "CommandRunner"
+    },
+    {
+      "schema": "dtmi:osconfig:networking;1",
+      "@type": "Component",
+      "name": "Networking"
+    },
+    {
+      "schema": "dtmi:osconfig:firewall;1",
+      "@type": "Component",
+      "name": "Firewall"
+    }
+  ]
+}

--- a/dtmi/osconfig/firewall-1.json
+++ b/dtmi/osconfig/firewall-1.json
@@ -1,0 +1,39 @@
+{
+  "@context": "dtmi:dtdl:context;2",
+  "@id": "dtmi:osconfig:firewall;1",
+  "@type": "Interface",
+  "displayName": "Firewall",
+  "description": "Provides functionality to remotely query firewall rules on device",
+  "contents": [
+    {
+      "@type": "Property",
+      "name": "FirewallRules",
+      "schema": {
+        "@type": "Object",
+        "fields": [
+           {
+            "name": "Directions",
+            "schema": "string"
+          },
+          {
+            "name": "Targets",
+            "schema": "string"
+          },
+          {
+            "name": "Protocols",
+            "schema": "string"
+          },
+          {
+            "name": "IpAddresses",
+            "schema": "string"
+          },
+          {
+            "name": "Ports",
+            "schema": "string"
+          }
+        ]
+      },
+      "writable": false
+    }
+  ]
+}


### PR DESCRIPTION
Signed-off-by: Marius Niculescu <mariusni@microsoft.com>

### Thank you for contributing to the Azure IoT Plug and Play Models repository

This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

The repository pipeline will ensure minimum validation of incoming DTDL models.  

- PR validation steps are described in the tools [Wiki](https://github.com/Azure/iot-plugandplay-models-tools/wiki/Validation-Pipeline#pr-validation-checks).
- The same validation can be run locally via the [dmr-client](https://github.com/Azure/iot-plugandplay-models-tools/tree/dev/clients/dotnet#device-model-repository-client) CLI.

## Requested info template for model(s) submission

When submitting models to the repository we ask that you provide as much of the following meta information around your models and related devices as possible. This info will be used to improve Plug and Play.

:star2: Please replace the markdown comment examples with your own values.

### Company Info

<!--
> Info identifying your company (if applicable).

Examples:
- Company name
- Company website
- GitHub presence
- Other

-->

### IoT Plug and Play Device Info

<!--
> Info identifying your PnP device.

Examples:
- Product website
- OS & Arch
- SDK used for model implementation
- Other

-->

### Model Submission Goals

<!--
> Info related to broader PnP goals.  

Examples:
- Device certification
- Presence in the [Certified Device catalog](https://devicecatalog.azure.com/)
- IoT Central integration
- Custom solution
- Other

-->

### Code Owners & Reserved Names

<!--
> Indicates GitHub alias entries to be added to the repo `CODEOWNERS` for the incoming model namespace. The codeowner is expected to be involved in subsequent DTDL model submissions against the same namespace.

If no alias is specified then we assume the PR submitter is responsible for the namespace.

Examples:
- @ContosoModelNamespaceOwner 1

-->
