### PR TITLE
Add model e1000_ibs01t, e1000_ibs03tp, x1000_ibs01t, x1000_ibs03tp

### DIFF
--- a/dtmi/ted/e1000_ibs01t-1.json
+++ b/dtmi/ted/e1000_ibs01t-1.json
@@ -1,0 +1,21 @@
+{
+  "@context": "dtmi:dtdl:context;2",
+  "@id": "dtmi:TED:E1000_iBS01T;1",
+  "@type": "Interface",
+  "displayName": "E1000_iBS01T",
+  "contents": [
+    {
+      "@type": "Component",
+      "name": "iBS01T",
+      "displayName": "iBS01T",
+      "schema": "dtmi:TED:iBS01T;1"
+    },
+    {
+      "@type": "Component",
+      "name": "deviceInformation",
+      "displayName": "Device Information interface",
+      "description": "Optional interface with basic device hardware information.",
+      "schema": "dtmi:azure:DeviceManagement:DeviceInformation;1"
+    }
+  ]
+}

--- a/dtmi/ted/e1000_ibs03tp-1.json
+++ b/dtmi/ted/e1000_ibs03tp-1.json
@@ -1,0 +1,21 @@
+{
+  "@context": "dtmi:dtdl:context;2",
+  "@id": "dtmi:TED:E1000_iBS03TP;1",
+  "@type": "Interface",
+  "displayName": "E1000_iBS03TP",
+  "contents": [
+    {
+      "@type": "Component",
+      "name": "iBS03TP",
+      "displayName": "iBS03TP",
+      "schema": "dtmi:TED:iBS03TP;1"
+    },
+    {
+      "@type": "Component",
+      "name": "deviceInformation",
+      "displayName": "Device Information interface",
+      "description": "Optional interface with basic device hardware information.",
+      "schema": "dtmi:azure:DeviceManagement:DeviceInformation;1"
+    }
+  ]
+}

--- a/dtmi/ted/ibs01t-1.json
+++ b/dtmi/ted/ibs01t-1.json
@@ -1,0 +1,61 @@
+{
+  "@context": "dtmi:dtdl:context;2",
+  "@id": "dtmi:TED:iBS01T;1",
+  "@type": "Interface",
+  "displayName": "iBS01T",
+  "contents": [
+    {
+      "@type": "Property",
+      "name": "telemetryInterval",
+      "displayName": "Telemetry Interval",
+      "description": "Control the frequency of the telemetry loop.",
+      "schema": "integer",
+      "writable": true
+    },
+    {
+      "@type": "Telemetry",
+      "name": "iBS01TObject",
+      "displayName": "iBS01T",
+      "schema": {
+        "@type": "Object",
+        "fields": [
+          {
+            "displayName": "Local Timestamp",
+            "name": "localtimestamp",
+            "schema": "string"
+          },
+          {
+            "displayName": "DatetimeISO",
+            "name": "datetimeISO",
+            "schema": "string"
+          },
+          {
+            "displayName": "RSSI",
+            "name": "rssi",
+            "schema": "integer"
+          },
+          {
+            "displayName": "Mac",
+            "name": "mac",
+            "schema": "string"
+          },
+          {
+            "displayName": "Temperature",
+            "name": "temperature",
+            "schema": "double"
+          },
+          {
+            "displayName": "Humidity",
+            "name": "humidity",
+            "schema": "double"
+          },
+          {
+            "displayName": "Battery",
+            "name": "battery",
+            "schema": "double"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/dtmi/ted/ibs03tp-1.json
+++ b/dtmi/ted/ibs03tp-1.json
@@ -1,0 +1,61 @@
+{
+  "@context": "dtmi:dtdl:context;2",
+  "@id": "dtmi:TED:iBS03TP;1",
+  "@type": "Interface",
+  "displayName": "iBS03TP",
+  "contents": [
+    {
+      "@type": "Property",
+      "name": "telemetryInterval",
+      "displayName": "Telemetry Interval",
+      "description": "Control the frequency of the telemetry loop.",
+      "schema": "integer",
+      "writable": true
+    },
+    {
+      "@type": "Telemetry",
+      "name": "iBS03TPObject",
+      "displayName": "iBS03TP",
+      "schema": {
+        "@type": "Object",
+        "fields": [
+          {
+            "displayName": "Local Timestamp",
+            "name": "localtimestamp",
+            "schema": "string"
+          },
+          {
+            "displayName": "DatetimeISO",
+            "name": "datetimeISO",
+            "schema": "string"
+          },
+          {
+            "displayName": "RSSI",
+            "name": "rssi",
+            "schema": "integer"
+          },
+          {
+            "displayName": "Mac",
+            "name": "mac",
+            "schema": "string"
+          },
+          {
+            "displayName": "Temperature",
+            "name": "temperature",
+            "schema": "double"
+          },
+          {
+            "displayName": "Temperature2",
+            "name": "temperature2",
+            "schema": "double"
+          },
+          {
+            "displayName": "Battery",
+            "name": "battery",
+            "schema": "double"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/dtmi/ted/x1000_ibs01t-1.json
+++ b/dtmi/ted/x1000_ibs01t-1.json
@@ -1,0 +1,21 @@
+{
+  "@context": "dtmi:dtdl:context;2",
+  "@id": "dtmi:TED:X1000_iBS01T;1",
+  "@type": "Interface",
+  "displayName": "X1000_iBS01T",
+  "contents": [
+    {
+      "@type": "Component",
+      "name": "iBS01T",
+      "displayName": "iBS01T",
+      "schema": "dtmi:TED:iBS01T;1"
+    },
+    {
+      "@type": "Component",
+      "name": "deviceInformation",
+      "displayName": "Device Information interface",
+      "description": "Optional interface with basic device hardware information.",
+      "schema": "dtmi:azure:DeviceManagement:DeviceInformation;1"
+    }
+  ]
+}

--- a/dtmi/ted/x1000_ibs03tp-1.json
+++ b/dtmi/ted/x1000_ibs03tp-1.json
@@ -1,0 +1,21 @@
+{
+  "@context": "dtmi:dtdl:context;2",
+  "@id": "dtmi:TED:X1000_iBS03TP;1",
+  "@type": "Interface",
+  "displayName": "X1000_iBS03TP",
+  "contents": [
+    {
+      "@type": "Component",
+      "name": "iBS03TP",
+      "displayName": "iBS03TP",
+      "schema": "dtmi:TED:iBS03TP;1"
+    },
+    {
+      "@type": "Component",
+      "name": "deviceInformation",
+      "displayName": "Device Information interface",
+      "description": "Optional interface with basic device hardware information.",
+      "schema": "dtmi:azure:DeviceManagement:DeviceInformation;1"
+    }
+  ]
+}


### PR DESCRIPTION
### Thank you for contributing to the Azure IoT Plug and Play Models repository

This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

The repository pipeline will ensure minimum validation of incoming DTDL models.  

- PR validation steps are described in the tools [Wiki](https://github.com/Azure/iot-plugandplay-models-tools/wiki/Validation-Pipeline#pr-validation-checks).
- The same validation can be run locally via the [dmr-client](https://github.com/Azure/iot-plugandplay-models-tools/tree/dev/clients/dotnet#device-model-repository-client) CLI.

## Requested info template for model(s) submission

When submitting models to the repository we ask that you provide as much of the following meta information around your models and related devices as possible. This info will be used to improve Plug and Play.

:star2: Please replace the markdown comment examples with your own values.

### Company Info

<!--
> Info identifying your company (if applicable).

Examples:
- Company name
- Company website
- GitHub presence
- Other

-->

### IoT Plug and Play Device Info

<!--
> Info identifying your PnP device.

Examples:
- Product website
- OS & Arch
- SDK used for model implementation
- Other

-->

### Model Submission Goals

<!--
> Info related to broader PnP goals.  

Examples:
- Device certification
- Presence in the [Certified Device catalog](https://devicecatalog.azure.com/)
- IoT Central integration
- Custom solution
- Other

-->

### Code Owners & Reserved Names

<!--
> Indicates GitHub alias entries to be added to the repo `CODEOWNERS` for the incoming model namespace. The codeowner is expected to be involved in subsequent DTDL model submissions against the same namespace.

If no alias is specified then we assume the PR submitter is responsible for the namespace.

Examples:
- @ContosoModelNamespaceOwner 1

-->
