### PR TITLE
Ritaylor/newazurespheremodel

### DIFF
--- a/dtmi/com/example/azuresphere/thermometer-1.json
+++ b/dtmi/com/example/azuresphere/thermometer-1.json
@@ -21,18 +21,18 @@
         {
             "@type": "Property",
             "displayName": {
-                "en": "Telemetry Upload Enabled"
+                "en": "Thermometer Telemetry Upload Enabled"
             },
-            "name": "telemetryUploadEnabled",
+            "name": "thermometerTelemetryUploadEnabled",
             "schema": "boolean",
             "writable": true
         },
         {
             "@type": "Telemetry",
             "displayName": {
-                "en": "Device Moved"
+                "en": "Thermometer Moved"
             },
-            "name": "deviceMoved",
+            "name": "thermometerMoved",
             "schema": "boolean"
         },
         {

--- a/dtmi/com/example/azuresphere/thermometer-1.json
+++ b/dtmi/com/example/azuresphere/thermometer-1.json
@@ -1,0 +1,75 @@
+{
+    "@context": [
+        "dtmi:iotcentral:context;2",
+        "dtmi:dtdl:context;2"
+    ],
+    "@id": "dtmi:com:example:azuresphere:thermometer;1",
+    "@type": "Interface",
+    "displayName": {
+        "en": "Azure Sphere Example Thermometer"
+    },
+    "contents": [
+        {
+            "@type": "Property",
+            "displayName": {
+              "en": "Serial Number"
+            },
+            "name": "serialNumber",
+            "schema": "string",
+            "writable": false
+        },
+        {
+            "@type": "Property",
+            "displayName": {
+                "en": "Telemetry Upload Enabled"
+            },
+            "name": "telemetryUploadEnabled",
+            "schema": "boolean",
+            "writable": true
+        },
+        {
+            "@type": "Telemetry",
+            "displayName": {
+                "en": "Device Moved"
+            },
+            "name": "deviceMoved",
+            "schema": "boolean"
+        },
+        {
+            "@type": [
+                "Telemetry",
+                "Temperature"
+            ],
+            "displayName": {
+                "en": "Temperature"
+            },
+            "name": "temperature",
+            "schema": "double",
+            "unit": "degreeCelsius"
+        },
+        {
+            "@type": "Command",
+            "commandType": "synchronous",
+            "displayName": {
+                "en": "Display Alert"
+            },
+            "name": "displayAlert",
+            "request": {
+                "@type": "CommandPayload",
+                "displayName": {
+                  "en": "Alert Message"
+                },
+                "name": "alertMessage",
+                "schema": "string"
+            },
+            "response": {
+                "@type": "CommandPayload",
+                "displayName": {
+                    "en": "Alert Result"
+                },
+                "name": "alertResult",
+                "schema": "string"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
### Thank you for contributing to the Azure IoT Plug and Play Models repository

This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

The repository pipeline will ensure minimum validation of incoming DTDL models.  

- PR validation steps are described in the tools [Wiki](https://github.com/Azure/iot-plugandplay-models-tools/wiki/Validation-Pipeline#pr-validation-checks).
- The same validation can be run locally via the [dmr-client](https://github.com/Azure/iot-plugandplay-models-tools/tree/dev/clients/dotnet#device-model-repository-client) CLI.

## Requested info template for model(s) submission

When submitting models to the repository we ask that you provide as much of the following meta information around your models and related devices as possible. This info will be used to improve Plug and Play.

:star2: Please replace the markdown comment examples with your own values.

### Company Info

Microsoft.  [Azure Sphere](https://azure.microsoft.com/en-us/services/azure-sphere/) team.

### IoT Plug and Play Device Info

We are updating this [sample app](https://github.com/Azure/azure-sphere-samples/tree/master/Samples/AzureIoT) that shows how to connect an Azure Sphere device to Azure IoT Hub or Azure IoT Central.  The new app will implement the data model in this PR, and submit its PnP ID upon connection.

### Model Submission Goals

This model is more clearly a domain specific example - a "thermometer".  We're doing this to avoid the impression that 
  1. this example model is specific to particular Azure Sphere dev kit (this example can be run on any Azure Sphere device).
  2. this example model would be used "as is" by customer Azure Sphere devices (they would write a new model specific to their own domain, as per the PnP documentation)

We will no longer use the existing [Azure Sphere sample device](https://github.com/Azure/iot-plugandplay-models/blob/main/dtmi/com/example/azuresphere/sampledevice-1.json) model - for the above reasons.  Please advise on if/how we should visibly deprecate or retire this model.

We don't currently intend to certify this model because, as explained, it doesn't directly pertain to a specific physical device.

### Code Owners & Reserved Names

- @cawhitworth
- @tokenstar
- @richardtaylorrt 
