### PR TITLE
Add AVCON models

### DIFF
--- a/dtmi/avcon/mps_h-1.json
+++ b/dtmi/avcon/mps_h-1.json
@@ -1,0 +1,13 @@
+{
+    "@context": "dtmi:dtdl:context;2",
+    "@id": "dtmi:AVCON:MPS_H;1",
+    "@type": "Interface",
+    "displayName": "AVCON-MPS-H",
+    "contents": [
+        {
+            "@type": "Component",
+            "name": "WindowsDeviceInfo1",
+            "schema": "dtmi:Synnex:WindowsDeviceInfo;1"
+        }
+    ]
+}

--- a/dtmi/avcon/orc100-1.json
+++ b/dtmi/avcon/orc100-1.json
@@ -1,0 +1,13 @@
+{
+    "@context": "dtmi:dtdl:context;2",
+    "@id": "dtmi:AVCON:ORC100;1",
+    "@type": "Interface",
+    "displayName": "AVCON-ORC100",
+    "contents": [
+        {
+            "@type": "Component",
+            "name": "WindowsDeviceInfo1",
+            "schema": "dtmi:Synnex:WindowsDeviceInfo;1"
+        }
+    ]
+}


### PR DESCRIPTION
### Company Info
AVCON
http://www.avcon.com.cn/
<!--
> Info identifying your company (if applicable).

Examples:
- Company name
- Company website
- GitHub presence
- Other

-->

### IoT Plug and Play Device Info
ORC100
http://www.avcon.com.cn/product/detail.aspx?id=25
MPS-H
http://www.avcon.com.cn/product/detail.aspx?id=97
<!--
> Info identifying your PnP device.

Examples:
- Product website
- OS & Arch
- SDK used for model implementation
- Other

-->

### Model Submission Goals
Device certification
<!--
> Info related to broader PnP goals.  

Examples:
- Device certification
- Presence in the [Certified Device catalog](https://devicecatalog.azure.com/)
- IoT Central integration
- Custom solution
- Other

-->

### Code Owners & Reserved Names

<!--
> Indicates GitHub alias entries to be added to the repo `CODEOWNERS` for the incoming model namespace. The codeowner is expected to be involved in subsequent DTDL model submissions against the same namespace.

If no alias is specified then we assume the PR submitter is responsible for the namespace.

Examples:
- @ContosoModelNamespaceOwner 1

-->
