### PR TITLE
Add Redeye-1-Plus-V2

### DIFF
--- a/dtmi/redeye/redeye_1_plus-2.json
+++ b/dtmi/redeye/redeye_1_plus-2.json
@@ -1,0 +1,85 @@
+{
+    "@context": "dtmi:dtdl:context;2",
+    "@id": "dtmi:Redeye:redeye_1_plus;2",
+    "@type": "Interface",
+    "displayName": "Redeye-1-Plus-V2",
+    "description": "Reports visible spectrophotometer for clinical use specified to detect microscale blood pollution in water.",
+    "contents": [
+        {
+            "@type": "Telemetry",
+            "name": "testResult",
+            "displayName": "Blood pollution test result",
+            "description": "1 is Positive, 2 is Negative, 3 is Unsure.",
+            "schema": {
+                "@type": "Enum",
+                "valueSchema": "integer",
+                "enumValues": [
+                  {
+                    "displayName": "Positive",
+                    "enumValue": 1,
+                    "name": "positive"
+                  },
+                  {
+                    "displayName": "Negative",
+                    "enumValue": 2,
+                    "name": "negative"
+                  },
+                  {
+                    "displayName": "Unsure",
+                    "enumValue": 3,
+                    "name": "unsure"
+                  }
+                ]
+            }
+        },
+        {
+            "@type": "Telemetry",
+            "name": "testResultSpectrum",
+            "displayName": "Blood pollution test result spectrum",
+            "description": "blank rate is water's spectrum ,sample rate is pollution water's spectrum, wavelength is spectrum's axis.",
+            "schema": {
+                "@type": "Array",
+                "displayName": "Spectrum",
+                "elementSchema": {
+                    "@type": "Object",
+                    "fields": [
+                        {
+                          "displayName": "Blank rate",
+                          "name": "blank",
+                          "schema": "double"
+                        },
+                        {
+                          "displayName": "Sample rate",
+                          "name": "sample",
+                          "schema": "double"
+                        },
+                        {
+                          "displayName": "Wavelength",
+                          "name": "wavelength",
+                          "schema": "double"
+                        }
+                      ]
+                }
+            }
+        },
+        {
+            "@type": "Property",
+            "name": "getCurrentConnectionStatus",
+            "displayName": "GetCurrentConnectionStatus",
+            "description": "Is the gateway connected to Redeye-1-Plus or not.",
+            "schema": "boolean"
+        },
+        {
+            "@type": "Command",
+            "name": "reboot",
+            "displayName": "Reboot",
+            "description": "Reboots the gateway."
+        },
+        {
+          "@type": "Command",
+          "name": "connectToRedeyeDevice",
+          "displayName": "ConnectToRedeyeDevice",
+          "description": "Scanning and try to connect Redeye-1-Plus near by."
+      }
+    ]
+}


### PR DESCRIPTION
### Company Info

<!--
> Info identifying your company (if applicable).

Examples:
- Company name
- Company website
- GitHub presence
- Other

-->
Taiwan RedEye Biomedical Inc.
[https://www.redeyebmi.com](https://www.redeyebmi.com)

### IoT Plug and Play Device Info

<!--
> Info identifying your PnP device.

Examples:
- Product website
- OS & Arch
- SDK used for model implementation
- Other

-->
[https://www.redeyebmi.com/product_detail.asp?id=1](https://www.redeyebmi.com/product_detail.asp?id=1)
Product name: RedEye Visible Spectrophotometer for clinical use
Model name: redeye 1 Plus
Model name of wireless charger: redeye-S
Trade Name: RedEye
Way of charging: 5V, 1A   (Wireless charging)
Place of production: Taiwan
Effective period: 5 years
Product content:   
                          ◆   Handheld device
                          ◆   Wireless Charger
                          ◆   Filter consumables (1 box )
                          ◆   Instruction for use
                          ◆   Accessories for wall mount and base

### Model Submission Goals

<!--
> Info related to broader PnP goals.  

Examples:
- Device certification
- Presence in the [Certified Device catalog](https://devicecatalog.azure.com/)
- IoT Central integration
- Custom solution
- Other

-->
Device Certification.

Use Banana-Pi-BPI-M64 on [Azure Certified Device catalog](https://devicecatalog.azure.com/devices/5cfad7c1-df2a-0086-bcc2-4d663178671d) as a gateway with provided image to connects RedEye-1-Plus through Wi-Fi and pushes test results to Azure IoT hub through wired LAN.

### Code Owners & Reserved Names

<!--
> Indicates GitHub alias entries to be added to the repo `CODEOWNERS` for the incoming model namespace. The codeowner is expected to be involved in subsequent DTDL model submissions against the same namespace.

If no alias is specified then we assume the PR submitter is responsible for the namespace.

Examples:
- @ContosoModelNamespaceOwner 1

-->

@Kolilmoon
