### PR TITLE
Create Vecow AIC-110 Model

### DIFF
--- a/dtmi/vecow/AIC-110
+++ b/dtmi/vecow/AIC-110
@@ -1,0 +1,13 @@
+{
+    "@context": "dtmi:dtdl:context;2",
+    "@id": "dtmi:VECOW:aic_110;1",
+    "@type": "Interface",
+    "displayName": "VECOW-AIC-110",
+    "contents": [
+        {
+            "@type": "Component",
+            "name": "LinuxDeviceInfo1",
+            "schema": "dtmi:Synnex:LinuxDeviceInfo;1"
+        }
+    ]
+}


### PR DESCRIPTION
### Thank you for contributing to the Azure IoT Plug and Play Models repository

This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

The repository pipeline will ensure minimum validation of incoming DTDL models.  

- PR validation steps are described in the tools [Wiki](https://github.com/Azure/iot-plugandplay-models-tools/wiki/Validation-Pipeline#pr-validation-checks).
- The same validation can be run locally via the [dmr-client](https://github.com/Azure/iot-plugandplay-models-tools/tree/dev/clients/dotnet#device-model-repository-client) CLI.

## Requested info template for model(s) submission

When submitting models to the repository we ask that you provide as much of the following meta information around your models and related devices as possible. This info will be used to improve Plug and Play.

:star2: Please replace the markdown comment examples with your own values.

### Company Info
Vecow
http://www.vecow.com

<!--
> Info identifying your company (if applicable).

Examples:
- Company name
- Company website
- GitHub presence
- Other

-->

### IoT Plug and Play Device Info
AIC-110
http://www.vecow.com/dispPageBox/vecow/VecowCT.aspx?ddsPageID=PRODUCTDTL_EN&dbid=4234574102

<!--
> Info identifying your PnP device.

Examples:
- Product website
- OS & Arch
- SDK used for model implementation
- Other

-->

### Model Submission Goals
Device Certification

<!--
> Info related to broader PnP goals.  

Examples:
- Device certification
- Presence in the [Certified Device catalog](https://devicecatalog.azure.com/)
- IoT Central integration
- Custom solution
- Other

-->

### Code Owners & Reserved Names

<!--
> Indicates GitHub alias entries to be added to the repo `CODEOWNERS` for the incoming model namespace. The codeowner is expected to be involved in subsequent DTDL model submissions against the same namespace.

If no alias is specified then we assume the PR submitter is responsible for the namespace.

Examples:
- @ContosoModelNamespaceOwner 1

-->
