### PR TITLE
Add models for E-Kit EnOcean Sensors and gateways

### DIFF
--- a/dtmi/com/e_kit/eep/a5_02_05-1.json
+++ b/dtmi/com/e_kit/eep/a5_02_05-1.json
@@ -1,0 +1,31 @@
+{
+  "@context": "dtmi:dtdl:context;2",
+  "@id": "dtmi:com:e_kit:eep:A5_02_05;1",
+  "@type": "Interface",
+  "displayName": "EnOcean Temperature Sensor EEP A5-02-05",
+  "description": "Temperature Sensor Range 0..40 degree.",
+  "contents": [
+    {
+      "@type": [ "Telemetry", "Temperature" ],
+      "name": "tp",
+      "displayName": "Temperature",
+      "description": "Temperature in degrees Celsius.",
+      "schema": "double",
+      "unit": "degreeCelsius"
+    },
+    {
+      "@type": "Property",
+      "name": "dbm",
+      "displayName": "Radio",
+      "description": "Radio strength in dBm.",
+      "schema": "integer"
+    },
+    {
+      "@type": "Property",
+      "name": "id",
+      "displayName": "EURID",
+      "description": "EnOcean Unique Radio Identifier.",
+      "schema": "string"
+    }
+  ]
+}

--- a/dtmi/com/e_kit/eep/a5_04_01-1.json
+++ b/dtmi/com/e_kit/eep/a5_04_01-1.json
@@ -1,0 +1,39 @@
+{
+  "@context": "dtmi:dtdl:context;2",
+  "@id": "dtmi:com:e_kit:eep:A5_04_01;1",
+  "@type": "Interface",
+  "displayName": "EnOcean Temperature and Humidity Sensor EEP A5-04-01",
+  "description": "Reports temperature and humidity status.",
+  "contents": [
+    {
+      "@type": [ "Telemetry", "Temperature" ],
+      "name": "tmp",
+      "displayName": "Temperature",
+      "description": "Temperature in degrees Celsius.",
+      "schema": "double",
+      "unit": "degreeCelsius"
+    },
+    {
+      "@type": [ "Telemetry", "RelativeHumidity" ],
+      "name": "hum",
+      "displayName": "Humidity",
+      "description": "RelativeHumidity in unity percent.",
+      "schema": "double",
+      "unit": "percent"
+    },
+    {
+      "@type": "Property",
+      "name": "dbm",
+      "displayName": "Radio",
+      "description": "Radio strength in dBm.",
+      "schema": "integer"
+    },
+    {
+      "@type": "Property",
+      "name": "id",
+      "displayName": "EURID",
+      "description": "EnOcean Unique Radio Identifier.",
+      "schema": "string"
+    }
+  ]
+}

--- a/dtmi/com/e_kit/eep/a5_07_01-1.json
+++ b/dtmi/com/e_kit/eep/a5_07_01-1.json
@@ -1,0 +1,53 @@
+{
+  "@context": "dtmi:dtdl:context;2",
+  "@id": "dtmi:com:e_kit:eep:A5_07_01;1",
+  "@type": "Interface",
+  "displayName": "EnOcean Occupancy Sensor EEP A5-07-01",
+  "description": "Reports Occupancy with supply voltage status.",
+  "contents": [
+    {
+      "@type": [ "Telemetry", "Voltage" ],
+      "name": "svc",
+      "displayName": "Temperature",
+      "description": "Temperature in degrees Celsius.",
+      "schema": "double",
+      "unit": "volt"
+    },
+    {
+      "@type": "Property",
+      "name": "pirs",
+      "displayName": "PIRSstatus",
+      "description": "PIRS status.",
+      "schema": {
+        "@type": "Enum",
+        "valueSchema": "integer",
+        "enumValues": [
+          {
+            "name": "off",
+            "displayName": "Uncertain",
+            "enumValue": 0
+          },
+          {
+            "name": "on",
+            "displayName": "Detected",
+            "enumValue": 1
+          }
+        ]
+      }
+    },
+    {
+      "@type": "Property",
+      "name": "dbm",
+      "displayName": "Radio",
+      "description": "Radio strength in dBm.",
+      "schema": "integer"
+    },
+    {
+      "@type": "Property",
+      "name": "id",
+      "displayName": "EURID",
+      "description": "EnOcean Unique Radio Identifier.",
+      "schema": "string"
+    }
+  ]
+}

--- a/dtmi/com/e_kit/eep/a5_09_04-1.json
+++ b/dtmi/com/e_kit/eep/a5_09_04-1.json
@@ -1,0 +1,46 @@
+{
+  "@context": "dtmi:dtdl:context;2",
+  "@id": "dtmi:com:e_kit:eep:A5_09_04;1",
+  "@type": "Interface",
+  "displayName": "EnOcean CO2 Gas sensor EEP A5-09-04",
+  "description": "Reports CO2 concentration, temperature, and humidity.",
+  "contents": [
+    {
+      "@type": [ "Telemetry", "RelativeHumidity" ],
+      "name": "hum",
+      "displayName": "Humidity",
+      "description": "RelativeHumidity in unity percent.",
+      "schema": "double",
+      "unit": "percent"
+    },
+    {
+      "@type": "Property",
+      "name": "conc",
+      "displayName": "Concentration",
+      "description": "Concentration in ppm.",
+      "schema": "integer"
+    },
+    {
+      "@type": [ "Telemetry", "Temperature" ],
+      "name": "tmp",
+      "displayName": "Temperature",
+      "description": "Temperature in degrees Celsius.",
+      "schema": "double",
+      "unit": "degreeCelsius"
+    },
+    {
+      "@type": "Property",
+      "name": "dbm",
+      "displayName": "Radio",
+      "description": "Radio strength in dBm.",
+      "schema": "integer"
+    },
+    {
+      "@type": "Property",
+      "name": "id",
+      "displayName": "EURID",
+      "description": "EnOcean Unique Radio Identifier.",
+      "schema": "string"
+    }
+  ]
+}

--- a/dtmi/com/e_kit/eep/d2_14_41-1.json
+++ b/dtmi/com/e_kit/eep/d2_14_41-1.json
@@ -1,0 +1,120 @@
+{
+  "@context": "dtmi:dtdl:context;2",
+  "@id": "dtmi:com:e_kit:eep:D2_14_41;1",
+  "@type": "Interface",
+  "displayName": "EnOcean Multisensor EEP D2-14-41",
+  "description": "Reports temperature, humidity, illuminance, acceleration, and contact status.",
+  "contents": [
+    {
+      "@type": [ "Telemetry", "Temperature" ],
+      "name": "tp",
+      "displayName": "Temperature",
+      "description": "Temperature in degrees Celsius.",
+      "schema": "double",
+      "unit": "degreeCelsius"
+    },
+    {
+      "@type": [ "Telemetry", "RelativeHumidity" ],
+      "name": "hu",
+      "displayName": "Humidity",
+      "description": "RelativeHumidity in unity percent.",
+      "schema": "double",
+      "unit": "percent"
+    },
+    {
+      "@type": [ "Telemetry", "Illuminance" ],
+      "name": "il",
+      "displayName": "Illuminance",
+      "description": "Illuminance in lux.",
+      "schema": "double",
+      "unit": "lux"
+    },
+    {
+      "@type": "Property",
+      "name": "as",
+      "displayName": "Accelerations",
+      "description": "Accelerations status.",
+      "schema": {
+        "@type": "Enum",
+        "valueSchema": "integer",
+        "enumValues": [
+          {
+            "name": "off",
+            "displayName": "Periodic Update",
+            "enumValue": 0
+          },
+          {
+            "name": "ex1",
+            "displayName": "Threshold 1 exceeded",
+            "enumValue": 1
+          },
+          {
+            "name": "ex2",
+            "displayName": "Threshold 2 exceeded",
+            "enumValue": 2
+          }
+        ]
+      }
+    },
+    {
+      "@type": [ "Telemetry", "Acceleration" ],
+      "name": "ax",
+      "displayName": "AccelerationX",
+      "description": "Acceleration X in gForce.",
+      "schema": "double",
+      "unit": "gForce"
+    },
+    {
+      "@type": [ "Telemetry", "Acceleration" ],
+      "name": "ay",
+      "displayName": "AccelerationY",
+      "description": "Acceleration Y in gForce.",
+      "schema": "double",
+      "unit": "gForce"
+    },
+    {
+      "@type": [ "Telemetry", "Acceleration" ],
+      "name": "az",
+      "displayName": "AccelerationZ",
+      "description": "Acceleration Z in gForce.",
+      "schema": "double",
+      "unit": "gForce"
+    },
+    {
+      "@type": "Property",
+      "name": "co",
+      "displayName": "Contact",
+      "description": "Contact sensor status.",
+      "schema": {
+        "@type": "Enum",
+        "valueSchema": "integer",
+        "enumValues": [
+          {
+            "name": "open",
+            "displayName": "Open",
+            "enumValue": 0
+          },
+          {
+            "name": "close",
+            "displayName": "Close",
+            "enumValue": 1
+          }
+        ]
+      }
+    },
+    {
+      "@type": "Property",
+      "name": "dbm",
+      "displayName": "Radio",
+      "description": "Radio strength in dBm.",
+      "schema": "integer"
+    },
+    {
+      "@type": "Property",
+      "name": "id",
+      "displayName": "EURID",
+      "description": "EnOcean Unique Radio Identifier.",
+      "schema": "string"
+    }
+  ]
+}

--- a/dtmi/com/e_kit/eep/d2_32_02-1.json
+++ b/dtmi/com/e_kit/eep/d2_32_02-1.json
@@ -1,0 +1,91 @@
+{
+  "@context": "dtmi:dtdl:context;2",
+  "@id": "dtmi:com:e_kit:eep:D2_32_02;1",
+  "@type": "Interface",
+  "displayName": "EnOcean A.C. Current Clamp EEP D2-32-02",
+  "description": "Reports 3ch. current value every 30 seconds.",
+  "contents": [
+    {
+      "@type": "Property",
+      "name": "pf",
+      "displayName": "PowerFail",
+      "description": "Power fail status.",
+      "schema": {
+        "@type": "Enum",
+        "valueSchema": "integer",
+        "enumValues": [
+          {
+            "name": "false",
+            "displayName": "False",
+            "enumValue": 0
+          },
+          {
+            "name": "true",
+            "displayName": "True",
+            "enumValue": 1
+          }
+        ]
+      }
+    },
+    {
+      "@type": "Property",
+      "name": "div",
+      "displayName": "Divisor",
+      "description": "Divisor status.",
+      "schema": {
+        "@type": "Enum",
+        "valueSchema": "integer",
+        "enumValues": [
+            {
+              "name": "x1",
+              "displayName": "x/1",
+              "enumValue": 0
+            },
+            {
+              "name": "x10",
+              "displayName": "x/10",
+              "enumValue": 1
+            }
+          ]
+        }
+      },
+      {
+      "@type": [ "Telemetry", "Current" ],
+      "name": "ch1",
+      "displayName": "Current1",
+      "description": "Current ch1 in ampere.",
+      "schema": "integer",
+      "unit": "ampere"
+    },
+    {
+        "@type": [ "Telemetry", "Current" ],
+        "name": "ch2",
+        "displayName": "Current2",
+        "description": "Current ch2 in ampere.",
+        "schema": "integer",
+        "unit": "ampere"
+      },
+      {
+        "@type": [ "Telemetry", "Current" ],
+        "name": "ch3",
+        "displayName": "Current3",
+        "description": "Current ch3 in ampere.",
+        "schema": "integer",
+        "unit": "ampere"
+      },
+        {
+      "@type": "Property",
+      "name": "dbm",
+      "displayName": "Radio",
+      "description": "Radio strength in dBm.",
+      "schema": "integer"
+    },
+    {
+      "@type": "Property",
+      "name": "id",
+      "displayName": "EURID",
+      "description": "EnOcean Unique Radio Identifier.",
+      "schema": "string"
+    }
+  ]
+}

--- a/dtmi/com/e_kit/eep/d5_00_01-1.json
+++ b/dtmi/com/e_kit/eep/d5_00_01-1.json
@@ -1,0 +1,45 @@
+{
+  "@context": "dtmi:dtdl:context;2",
+  "@id": "dtmi:com:e_kit:eep:D2_14_41;1",
+  "@type": "Interface",
+  "displayName": "EnOcean Contact sensor EEP D5-00-01",
+  "description": "Reports contact status.",
+  "contents": [
+    {
+      "@type": "Property",
+      "name": "co",
+      "displayName": "contact",
+      "description": "Contact sensor status.",
+      "schema": {
+        "@type": "Enum",
+        "valueSchema": "integer",
+        "enumValues": [
+          {
+            "name": "open",
+            "displayName": "Open",
+            "enumValue": 0
+          },
+          {
+            "name": "close",
+            "displayName": "Close",
+            "enumValue": 1
+          }
+        ]
+      }
+    },
+    {
+      "@type": "Property",
+      "name": "dbm",
+      "displayName": "Radio",
+      "description": "Radio strength in dBm.",
+      "schema": "integer"
+    },
+    {
+      "@type": "Property",
+      "name": "id",
+      "displayName": "EURID",
+      "description": "EnOcean Unique Radio Identifier.",
+      "schema": "string"
+    }
+  ]
+}

--- a/dtmi/com/e_kit/testdev/TemperatureController.json
+++ b/dtmi/com/e_kit/testdev/TemperatureController.json
@@ -1,0 +1,58 @@
+{
+  "@context": "dtmi:dtdl:context;2",
+  "@id": "dtmi:com:e_kit:testdev:TemperatureController;1",
+  "@type": "Interface",
+  "displayName": "Temperature Controller",
+  "description": "Device with two thermostats and remote reboot.",
+  "contents": [    {
+      "@type": [
+        "Telemetry", "DataSize"
+      ],
+      "name": "workingSet",
+      "displayName": "Working Set",
+      "description": "Current working set of the device memory in KiB.",
+      "schema": "double",
+      "unit" : "kibibyte"
+    },
+    {
+      "@type": "Property",
+      "name": "serialNumber",
+      "displayName": "Serial Number",
+      "description": "Serial number of the device.",
+      "schema": "string"
+    },
+    {
+      "@type": "Command",
+      "name": "reboot",
+      "displayName": "Reboot",
+      "description": "Reboots the device after waiting the number of seconds specified.",
+      "request": {
+        "name": "delay",
+        "displayName": "Delay",
+        "description": "Number of seconds to wait before rebooting the device.",
+        "schema": "integer"
+      }
+    },
+    {
+      "@type" : "Component",
+      "schema": "dtmi:com:example:Thermostat;1",
+      "name": "thermostat1",
+      "displayName": "Thermostat One",
+      "description": "Thermostat One of Two."
+    },
+    {
+      "@type" : "Component",
+      "schema": "dtmi:com:example:Thermostat;1",
+      "name": "thermostat2",
+      "displayName": "Thermostat Two",
+      "description": "Thermostat Two of Two."
+    },
+    {
+      "@type": "Component",
+      "schema": "dtmi:azure:DeviceManagement:DeviceInformation;1",
+      "name": "deviceInformation",
+      "displayName": "Device Information interface",
+      "description": "Optional interface with basic device hardware information."
+    }
+  ]
+}


### PR DESCRIPTION
### Thank you for contributing to the Azure IoT Plug and Play Models repository

This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

The repository pipeline will ensure minimum validation of incoming DTDL models.  

- PR validation steps are described in the tools [Wiki](https://github.com/Azure/iot-plugandplay-models-tools/wiki/Validation-Pipeline#pr-validation-checks).
- The same validation can be run locally via the [dmr-client](https://github.com/Azure/iot-plugandplay-models-tools/tree/dev/clients/dotnet#device-model-repository-client) CLI.

## Requested info template for model(s) submission

When submitting models to the repository we ask that you provide as much of the following meta information around your models and related devices as possible. This info will be used to improve Plug and Play.

:star2: Please replace the markdown comment examples with your own values.

### Company Info

<!--
> Info identifying your company (if applicable).

- Company name

  Device Drivers Limited

- Company website

  http://www.devdrv.co.jp/
  
- GitHub presence

  https://github.com/devdrv/

- Other

  we have web sites http://www.devdrv.com/  and http://e-kit.con/ , too.


### IoT Plug and Play Device Info

- Product website

  http://e-kit.jp/products/EnOcean/EO-DCGW

  http://www2.e-kit.jp/products/EnOcean/index.htm#EO-EKITGW

  http://www.devdrv.co.jp/products/

- OS & Arch

  raspberry pi OS 

  Raspberry Pi 3 Model B (Broadcom BCM2837 ARM Cortex-A53)

- SDK used for model implementation

  azure-iot-sdk-c

- Other

### Model Submission Goals

- Device certification

  Hope.

- Presence in the [Certified Device catalog](https://devicecatalog.azure.com/)

  Hope.

- IoT Central integration

  Developing now.

- Custom solution

  Developing now.

- Other

-->

### Code Owners & Reserved Names

<!--
> Indicates GitHub alias entries to be added to the repo `CODEOWNERS` for the incoming model namespace. The codeowner is expected to be involved in subsequent DTDL model submissions against the same namespace.

If no alias is specified then we assume the PR submitter is responsible for the namespace.

Examples:
- @ContosoModelNamespaceOwner 1

-->
