### PR TITLE
Add AAEON Interfaces.

### DIFF
--- a/dtmi/aaeon/gene_whu6-1.json
+++ b/dtmi/aaeon/gene_whu6-1.json
@@ -1,0 +1,21 @@
+{
+    "@id": "dtmi:AAEON:GENE_WHU6;1",
+    "@type": "Interface",
+    "displayName": "GENE-WHU6",
+    "@context": [
+        "dtmi:iotcentral:context;2",
+        "dtmi:dtdl:context;2"
+    ],
+    "contents": [
+        {
+            "@type": "Component",
+            "name": "deviceInformation",
+            "schema": "dtmi:azure:DeviceManagement:DeviceInformation;1"
+        },
+        {
+            "@type": "Component",
+            "name": "HWMonitor",
+            "schema": "dtmi:AAEON:HardwareMonitor;1"
+        }
+    ]
+}

--- a/dtmi/aaeon/hardwaremonitor-1.json
+++ b/dtmi/aaeon/hardwaremonitor-1.json
@@ -1,0 +1,101 @@
+{
+    "@id": "dtmi:AAEON:HardwareMonitor;1",
+    "@type": "Interface",
+    "displayName": "Hardware Monitor",
+    "@context": [
+        "dtmi:iotcentral:context;2",
+        "dtmi:dtdl:context;2"
+    ],
+    "contents": [
+        {
+            "@type": "Telemetry",
+            "displayName": "CPU Temperature",
+            "name": "tempCPU",
+            "schema": "integer"
+        },
+        {
+            "@type": "Telemetry",
+            "displayName": "System 1 Temperature",
+            "name": "tempSystem1",
+            "schema": "integer"
+        },
+        {
+            "@type": "Telemetry",
+            "displayName": "System 2 Temperature",
+            "name": "tempSystem2",
+            "schema": "integer"
+        },
+        {
+            "@type": "Telemetry",
+            "displayName": "CPU Fan Speed",
+            "name": "fanSpeedCPU",
+            "schema": "integer"
+        },
+        {
+            "@type": "Telemetry",
+            "displayName": "System 1 Fan Speed",
+            "name": "fanSpeedSystem1",
+            "schema": "integer"
+        },
+        {
+            "@type": "Telemetry",
+            "displayName": "System 2 Fan Speed",
+            "name": "fanSpeedSystem2",
+            "schema": "integer"
+        },
+        {
+            "@type": "Telemetry",
+            "displayName": "VCORE",
+            "name": "vCORE",
+            "schema": "integer"
+          },
+          {
+            "@type": "Telemetry",
+            "displayName": "2V5",
+            "name": "v2V5",
+            "schema": "integer"
+          },
+          {
+            "@type": "Telemetry",
+            "displayName": "3V3",
+            "name": "v3V3",
+            "schema": "integer"
+          },
+          {
+            "@type": "Telemetry",
+            "displayName": "3VSB",
+            "name": "v3VSB",
+            "schema": "integer"
+          },
+          {
+            "@type": "Telemetry",
+            "displayName": "VBAT",
+            "name": "vBAT",
+            "schema": "integer"
+          },
+          {
+            "@type": "Telemetry",
+            "displayName": "5V",
+            "name": "v5V",
+            "schema": "integer"
+          },
+          {
+            "@type": "Telemetry",
+            "displayName": "5VSB",
+            "name": "v5VSB",
+            "schema": "integer"
+          },
+          {
+            "@type": "Telemetry",
+            "displayName": "12V",
+            "name": "v12V",
+            "schema": "integer"
+          },
+          {
+            "@type": "Telemetry",
+            "displayName": "DIMM",
+            "name": "vDIMM",
+            "schema": "integer"
+          }
+    ]
+}


### PR DESCRIPTION
1. Add hardware monitor interface that monitors temperature, fan speed and voltage.
2. Add GENE-WHU6 model.

### Thank you for contributing to the Azure IoT Plug and Play Models repository

This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

The repository pipeline will ensure minimum validation of incoming DTDL models.  

- PR validation steps are described in the tools [Wiki](https://github.com/Azure/iot-plugandplay-models-tools/wiki/Validation-Pipeline#pr-validation-checks).
- The same validation can be run locally via the [dmr-client](https://github.com/Azure/iot-plugandplay-models-tools/tree/dev/clients/dotnet#device-model-repository-client) CLI.

## Requested info template for model(s) submission

When submitting models to the repository we ask that you provide as much of the following meta information around your models and related devices as possible. This info will be used to improve Plug and Play.

:star2: Please replace the markdown comment examples with your own values.

### Company Info

- Company name : AAEON
- Company website : [AAEON Website](https://www.aaeon.com/en/)

### IoT Plug and Play Device Info

- Project website : [GENE-WHU6](https://www.aaeon.com/en/p/sub-compact-boards-gene-whu6)
    - This product is designed as an embedded single board computers. 
    - Detailed specs could refer to the link. 

### Model Submission Goals

As a partner of Microsoft, we had passed this product within Azure IoT Pnp Cerification preview version.
To follow the newest Azure IoT Pnp, we update our device application that could works better than before.

### Code Owners & Reserved Names

<!--
> Indicates GitHub alias entries to be added to the repo `CODEOWNERS` for the incoming model namespace. The codeowner is expected to be involved in subsequent DTDL model submissions against the same namespace.

If no alias is specified then we assume the PR submitter is responsible for the namespace.

Examples:
- @ContosoModelNamespaceOwner 1

-->
