### PR TITLE
add wioterminal/wioterminal_aziot_example-7.json

### DIFF
--- a/dtmi/seeedkk/wioterminal/wioterminal_aziot_example-7.json
+++ b/dtmi/seeedkk/wioterminal/wioterminal_aziot_example-7.json
@@ -1,0 +1,82 @@
+{
+    "@id": "dtmi:seeedkk:wioterminal:wioterminal_aziot_example;7",   
+    "@type": "Interface",
+    "displayName": "Seeed Wio Terminal",
+    "contents": [
+      {
+        "@type": "Property",
+        "description": {
+          "en": "Right button pushed down."
+        },
+        "displayName": {
+          "en": "latestInferenceResult"
+        },
+        "name": "latestInferenceResult",
+        "schema": "string",
+        "writable": false
+      },
+      {
+        "@type": "Telemetry",
+        "description": {
+          "en": "X-axis value of accelerometer.",
+          "ja": "加速度センサーのX値です。"
+        },
+        "displayName": {
+          "en": "CO2",
+          "ja": "加速度 X"
+        },
+        "name": "CO2",
+        "schema": "double",
+        "unit": "gForce"
+      },
+      {
+        "@type": "Telemetry",
+        "description": {
+          "en": "Y-axis value of accelerometer.",
+          "ja": "加速度センサーのY値です。"
+        },
+        "displayName": {
+          "en": "N02",
+          "ja": "加速度 Y"
+        },
+        "name": "NO2",
+        "schema": "double",
+        "unit": "gForce"
+      },
+      {
+        "@type": "Telemetry",
+        "description": {
+          "en": "Z-axis value of accelerometer.",
+          "ja": "加速度センサーのZ値です。"
+        },
+        "displayName": {
+          "en": "C2H2OH",
+          "ja": "加速度 Z"
+        },
+        "name": "C2H2OH",
+        "schema": "double",
+        "unit": "gForce"
+      },
+      {
+        "@type": "Telemetry",
+        "description": {
+          "en": "Light sensor value (%) on backside.",
+          "ja": "背面にある光センサーの光量です。単位は%。"
+        },
+        "displayName": {
+          "en": "VO2",
+          "ja": "光量"
+        },
+        "name": "VO2",
+        "schema": "integer"
+      }
+    ],
+    "description": {
+      "en": "X,Y,Z-axis, brightness and button click polling result. Buzzer can be beeped by settings on cloud.",
+      "ja": "加速度X,Y,Zと光量を定期的に通知します。また、右、中央、左ボタンのクリックも通知します。クラウドからの指示でブザーが鳴ります。"
+    },
+    "@context": [
+      "dtmi:iotcentral:context;2",
+      "dtmi:dtdl:context;2"
+    ]
+  }

--- a/dtmi/seeedkk/wioterminal/wioterminal_aziot_example-7.json
+++ b/dtmi/seeedkk/wioterminal/wioterminal_aziot_example-7.json
@@ -17,63 +17,39 @@
       },
       {
         "@type": "Telemetry",
-        "description": {
-          "en": "X-axis value of accelerometer.",
-          "ja": "加速度センサーのX値です。"
-        },
         "displayName": {
-          "en": "CO2",
-          "ja": "加速度 X"
+          "en": "CO2"
         },
         "name": "CO2",
-        "schema": "double",
-        "unit": "gForce"
+        "schema": "double"
       },
       {
         "@type": "Telemetry",
-        "description": {
-          "en": "Y-axis value of accelerometer.",
-          "ja": "加速度センサーのY値です。"
-        },
         "displayName": {
-          "en": "N02",
-          "ja": "加速度 Y"
+          "en": "N02"
         },
         "name": "NO2",
-        "schema": "double",
-        "unit": "gForce"
+        "schema": "double"
       },
       {
         "@type": "Telemetry",
-        "description": {
-          "en": "Z-axis value of accelerometer.",
-          "ja": "加速度センサーのZ値です。"
-        },
         "displayName": {
-          "en": "C2H2OH",
-          "ja": "加速度 Z"
+          "en": "C2H2OH"
         },
         "name": "C2H2OH",
-        "schema": "double",
-        "unit": "gForce"
+        "schema": "double"
       },
       {
         "@type": "Telemetry",
-        "description": {
-          "en": "Light sensor value (%) on backside.",
-          "ja": "背面にある光センサーの光量です。単位は%。"
-        },
         "displayName": {
-          "en": "VO2",
-          "ja": "光量"
+          "en": "VO2"
         },
         "name": "VO2",
         "schema": "integer"
       }
     ],
     "description": {
-      "en": "X,Y,Z-axis, brightness and button click polling result. Buzzer can be beeped by settings on cloud.",
-      "ja": "加速度X,Y,Zと光量を定期的に通知します。また、右、中央、左ボタンのクリックも通知します。クラウドからの指示でブザーが鳴ります。"
+      "en": "Smell nose"
     },
     "@context": [
       "dtmi:iotcentral:context;2",


### PR DESCRIPTION
### Thank you for contributing to the Azure IoT Plug and Play Models repository

This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

The repository pipeline will ensure minimum validation of incoming DTDL models.  

- PR validation steps are described in the tools [Wiki](https://github.com/Azure/iot-plugandplay-models-tools/wiki/Validation-Pipeline#pr-validation-checks).
- The same validation can be run locally via the [dmr-client](https://github.com/Azure/iot-plugandplay-models-tools/tree/dev/clients/dotnet#device-model-repository-client) CLI.

## Requested info template for model(s) submission

When submitting models to the repository we ask that you provide as much of the following meta information around your models and related devices as possible. This info will be used to improve Plug and Play.

:star2: Please replace the markdown comment examples with your own values.

### Company Info

<!--
> Info identifying your company (if applicable).

Examples:
- Company name
- Company website
- GitHub presence
- Other

-->

### IoT Plug and Play Device Info

<!--
> Info identifying your PnP device.

Examples:
- Product website
- OS & Arch
- SDK used for model implementation
- Other

-->

### Model Submission Goals

<!--
> Info related to broader PnP goals.  

Examples:
- Device certification
- Presence in the [Certified Device catalog](https://devicecatalog.azure.com/)
- IoT Central integration
- Custom solution
- Other

-->

### Code Owners & Reserved Names

<!--
> Indicates GitHub alias entries to be added to the repo `CODEOWNERS` for the incoming model namespace. The codeowner is expected to be involved in subsequent DTDL model submissions against the same namespace.

If no alias is specified then we assume the PR submitter is responsible for the namespace.

Examples:
- @ContosoModelNamespaceOwner 1

-->
