### PR TITLE
Increment to dmr-client beta5

### DIFF
--- a/.azure-devops/sync_models.yml
+++ b/.azure-devops/sync_models.yml
@@ -58,11 +58,8 @@ jobs:
       targetType: 'inline'
       script: |
         set -e
-        
-        git clone -b $(dmrClientVer) https://github.com/Azure/iot-plugandplay-models-tools ../dmrtools
-        PATH=../dmrtools:$PATH
-        dotnet pack ../dmrtools/clients/dotnet -v m -c Release
-        dotnet tool install Microsoft.IoT.ModelsRepository.CommandLine --tool-path ../dmrtools --add-source ../dmrtools/clients/dotnet/Microsoft.IoT.ModelsRepository.CommandLine/bin/Release/ --version $(dmrClientVer)
+
+        dotnet tool install -g Microsoft.IoT.ModelsRepository.CommandLine --version 1.0.0-beta.5
 
         echo "Expanding repository..."
         dmr-client expand --local-repo $PWD

--- a/.azure-devops/sync_models_azcopy.yml
+++ b/.azure-devops/sync_models_azcopy.yml
@@ -45,10 +45,7 @@ jobs:
       script: |
         set -e
         
-        git clone -b $(dmrClientVer) https://github.com/Azure/iot-plugandplay-models-tools ../dmrtools
-        PATH=../dmrtools:$PATH
-        dotnet pack ../dmrtools/clients/dotnet -v m -c Release
-        dotnet tool install Microsoft.IoT.ModelsRepository.CommandLine --tool-path ../dmrtools --add-source ../dmrtools/clients/dotnet/Microsoft.IoT.ModelsRepository.CommandLine/bin/Release/ --version $(dmrClientVer)
+        dotnet tool install -g Microsoft.IoT.ModelsRepository.CommandLine --version 1.0.0-beta.5
 
         echo "Expanding repository..."
         dmr-client expand --local-repo $PWD

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,7 +5,7 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 The repository pipeline will ensure minimum validation of incoming DTDL models.  
 
 - PR validation steps are described in the tools [Wiki](https://github.com/Azure/iot-plugandplay-models-tools/wiki/Validation-Pipeline#pr-validation-checks).
-- The same validation can be run locally via the [dmr-client](https://github.com/Azure/iot-plugandplay-models-tools/tree/dev/clients/dotnet#device-model-repository-client) CLI.
+- The same validation can be run locally via the [dmr-client](https://github.com/Azure/iot-plugandplay-models-tools/tree/dev/clients/dotnet/Microsoft.IoT.ModelsRepository.CommandLine) command line tool.
 
 ## Requested info template for model(s) submission
 

--- a/.github/workflows/validate_models.yml
+++ b/.github/workflows/validate_models.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Install Microsoft.IoT.ModelsRepository.CommandLine (dmr-client) from NuGet
         run: |
-          dotnet tool install -g Microsoft.IoT.ModelsRepository.CommandLine --version 1.0.0-beta.4
+          dotnet tool install -g Microsoft.IoT.ModelsRepository.CommandLine --version 1.0.0-beta.5
 
       - name: Checkout repository models
         uses: actions/checkout@v2


### PR DESCRIPTION
* Use beta5 for validation.
* Use beta5 (and switch to NuGet package) for publishing pipeline.

