### PR TITLE
Add AIS 4G Board example model V1.0

### DIFF
--- a/dtmi/ais/ais_4g_board/ais_4g_board_example-1.json
+++ b/dtmi/ais/ais_4g_board/ais_4g_board_example-1.json
@@ -2,7 +2,7 @@
         "@id": "dtmi:ais:ais_4g_board:ais_4g_board_example;1",
         "@type": "Interface",
         "displayName": {
-            "en": "AIS 4G board"
+            "en": "AIS 4G Board"
         },
         "@context": "dtmi:dtdl:context;2",
         "contents": [


### PR DESCRIPTION
### Company Info

- [Advanced Info Services Public Company Limited](www.ais.th)

### IoT Plug and Play Device Info

AIS 4G Board is a compact circuit board built for use in IoT development via 4G network using a market-leading microcontroller module from Espressif, model "ESP32-WROOM-32" and 4G communication module from SIMCom, model "SIM7600E-H1C", which supports LTE Cat 4 signals. This board has been designed and manufactured as a 4-Layer PCB according to engineering standards specified by IPC and includes built-in circuit protection in the form of transient-voltage-suppression of each I/O pins. The board itself has many incredible and useful functions. For example, there are two USB Type-C connectors: one for direct connection to SIM7600E-H1C, and the other for ESP32-WROOM-32 via the FTDI chip, which acts as a USB-to-Serial converter that is stable and supports all operating systems. There is an on-board temperature and humidity sensor, also includes several LED indicators, an RS485 port, GPS for location tracking, ESIM is pre-installed onto the board so no additional SIM installation is required, a MicroSD card slot for data logging. And the most unique thing about this product is its ability to promptly connect to the Microsoft Azure cloud services.

see more: https://devicecatalog.azure.com/devices/d845f884-e516-4ced-9bd8-7410a1e0ca8f

### Model Submission Goals

- Device certification
- Presence in the [Certified Device catalog](https://devicecatalog.azure.com/)
- IoT Central integration

### Code Owners & Reserved Names

- @maxpromer
- @gravitech-engineer
