### PR TITLE
Add Vecow EIC-1000 model

### DIFF
--- a/dtmi/vecow/aic_100-1.json
+++ b/dtmi/vecow/aic_100-1.json
@@ -1,0 +1,13 @@
+{
+    "@context": "dtmi:dtdl:context;2",
+    "@id": "dtmi:VECOW:aic_100;1",
+    "@type": "Interface",
+    "displayName": "VECOW-AIC-100",
+    "contents": [
+        {
+            "@type": "Component",
+            "name": "LinuxDeviceInfo1",
+            "schema": "dtmi:Synnex:LinuxDeviceInfo;1"
+        }
+    ]
+}

--- a/dtmi/vecow/aic_110-1.json
+++ b/dtmi/vecow/aic_110-1.json
@@ -1,0 +1,13 @@
+{
+    "@context": "dtmi:dtdl:context;2",
+    "@id": "dtmi:VECOW:aic_110;1",
+    "@type": "Interface",
+    "displayName": "VECOW-AIC-110",
+    "contents": [
+        {
+            "@type": "Component",
+            "name": "LinuxDeviceInfo1",
+            "schema": "dtmi:Synnex:LinuxDeviceInfo;1"
+        }
+    ]
+}

--- a/dtmi/vecow/aig_100-1.json
+++ b/dtmi/vecow/aig_100-1.json
@@ -1,0 +1,13 @@
+{
+    "@context": "dtmi:dtdl:context;2",
+    "@id": "dtmi:VECOW:aig_100;1",
+    "@type": "Interface",
+    "displayName": "VECOW-AIG-100",
+    "contents": [
+        {
+            "@type": "Component",
+            "name": "LinuxDeviceInfo1",
+            "schema": "dtmi:Synnex:LinuxDeviceInfo;1"
+        }
+    ]
+}

--- a/dtmi/vecow/eic_1000-1.json
+++ b/dtmi/vecow/eic_1000-1.json
@@ -1,0 +1,13 @@
+{
+    "@context": "dtmi:dtdl:context;2",
+    "@id": "dtmi:VECOW:eic_1000;1",
+    "@type": "Interface",
+    "displayName": "VECOW-EIC-1000",
+    "contents": [
+        {
+            "@type": "Component",
+            "name": "LinuxDeviceInfo1",
+            "schema": "dtmi:Synnex:LinuxDeviceInfo;1"
+        }
+    ]
+}


### PR DESCRIPTION
### Company Info

- Company name: Vecow
- Company website: https://www.vecow.com/

### IoT Plug and Play Device Info

- Product name: EIC-1000
- Product website:https://www.vecow.com/dispPageBox/vecow/VecowCT.aspx?ddsPageID=PRODUCTDTL_EN&dbid=4739576457
- OS: Android & Debian

### Model Submission Goals

- Device certification

### Code Owners & Reserved Names
