### PR TITLE
Added asset tracker v2, generic v1, and lora edge tracker v1.

### DIFF
--- a/dtmi/tartabit/assettracker-2.json
+++ b/dtmi/tartabit/assettracker-2.json
@@ -1,0 +1,173 @@
+{
+	"@id": "dtmi:tartabit:AssetTracker;2",
+	"@type": "Interface",
+	"displayName": {
+		"en": "Tartabit Asset Tracker"
+	},
+	"@context": [
+		"dtmi:iotcentral:context;2",
+		"dtmi:dtdl:context;2"
+	],
+	"contents": [
+		{
+			"@type": [
+				"Telemetry",
+				"Location"
+			],
+			"displayName": {
+				"en": "Location"
+			},
+			"name": "location",
+			"schema": "geopoint"
+		},
+		{
+			"@type": [
+				"Telemetry",
+				"Velocity"
+			],
+			"displayName": {
+				"en": "Speed"
+			},
+			"name": "speed",
+			"schema": "double",
+			"unit": "milePerHour"
+		},
+		{
+			"@type": [
+				"Telemetry",
+				"Angle"
+			],
+			"displayName": {
+				"en": "Heading"
+			},
+			"name": "heading",
+			"schema": "double",
+			"unit": "degreeOfArc"
+		},
+		{
+			"@type": "Telemetry",
+			"displayName": {
+				"en": "Moving"
+			},
+			"name": "moving",
+			"schema": "boolean"
+		},
+		{
+			"@type": [
+				"Telemetry",
+				"Temperature"
+			],
+			"displayName": {
+				"en": "Temperature"
+			},
+			"name": "temperature",
+			"schema": "double",
+			"unit": "degreeCelsius"
+		},
+		{
+			"@type": "Telemetry",
+			"displayName": {
+				"en": "RSSI"
+			},
+			"name": "rssi",
+			"schema": "double"
+		},
+		{
+			"@type": "Telemetry",
+			"displayName": {
+				"en": "Battery"
+			},
+			"name": "battery",
+			"schema": "double"
+		},
+		{
+			"@type": "Telemetry",
+			"displayName": {
+				"en": "Reason"
+			},
+			"name": "reason",
+			"schema": "string"
+		},
+		{
+			"@type": "Property",
+			"displayName": {
+				"en": "Address"
+			},
+			"name": "address",
+			"schema": "string",
+			"writable": false
+		},
+		{
+			"@type": "Property",
+			"displayName": {
+				"en": "Firmware Version"
+			},
+			"name": "firmwareVersion",
+			"schema": "string",
+			"writable": false
+		},
+		{
+			"@type": "Property",
+			"displayName": {
+				"en": "IMEI"
+			},
+			"name": "imei",
+			"schema": "string",
+			"writable": false
+		},
+		{
+			"@type": "Property",
+			"displayName": {
+				"en": "ICCID"
+			},
+			"name": "iccid",
+			"schema": "string",
+			"writable": false
+		},
+		{
+			"@type": "Property",
+			"displayName": {
+				"en": "Network"
+			},
+			"name": "network",
+			"schema": {
+				"@type": "Object",
+				"fields": [
+					{
+						"displayName": {
+							"en": "Bearer"
+						},
+						"name": "bearer",
+						"schema": "string"
+					},
+					{
+						"displayName": {
+							"en": "Provider"
+						},
+						"name": "provider",
+						"schema": "string"
+					},
+					{
+						"displayName": {
+							"en": "RSSI"
+						},
+						"name": "rssi",
+						"schema": "double"
+					}
+				]
+			},
+			"writable": false
+		},
+		{
+			"@type": [
+				"Property",
+				"Location"
+			],
+			"displayName": {
+				"en": "Last Known Location"
+			},
+			"name": "lastKnownLocation",
+			"schema": "geopoint"
+		}
+	]
+}

--- a/dtmi/tartabit/generic-1.json
+++ b/dtmi/tartabit/generic-1.json
@@ -1,0 +1,178 @@
+{
+	"@id": "dtmi:tartabit:Generic;1",
+	"@type": "Interface",
+	"displayName": {
+		"en": "Generic Device"
+	},
+	"@context": [
+		"dtmi:iotcentral:context;2",
+		"dtmi:dtdl:context;2"
+	],
+	"contents": [
+		{
+			"@type": [
+				"Telemetry",
+				"Event"
+			],
+			"displayName": {
+				"en": "Event"
+			},
+			"name": "event",
+			"schema": "string"
+		},
+		{
+			"@type": [
+				"Telemetry",
+				"Location"
+			],
+			"displayName": {
+				"en": "Location"
+			},
+			"name": "location",
+			"schema": "geopoint"
+		},
+		{
+			"@type": "Telemetry",
+			"displayName": {
+				"en": "Address"
+			},
+			"name": "address",
+			"schema": "string"
+		},
+		{
+			"@type": "Telemetry",
+			"displayName": {
+				"en": "Sensors"
+			},
+			"name": "sensors",
+			"schema": {
+				"@type": "Map",
+				"mapKey": {
+					"name": "sensor",
+					"schema": "string"
+				},
+				"mapValue": {
+					"name": "value",
+					"schema": {
+						"@type": "Object",
+						"fields": [
+							{
+								"displayName": {
+									"en": "Number"
+								},
+								"name": "number",
+								"schema": "double"
+							},
+							{
+								"displayName": {
+									"en": "String"
+								},
+								"name": "string",
+								"schema": "string"
+							},
+							{
+								"displayName": {
+									"en": "Boolean"
+								},
+								"name": "boolean",
+								"schema": "boolean"
+							}
+						]
+					}
+				}
+			}
+		},
+		{
+			"@type": "Property",
+			"displayName": {
+				"en": "Last Known Address"
+			},
+			"name": "lastKnownAddress",
+			"schema": "string",
+			"writable": false
+		},
+		{
+			"@type": [
+				"Property",
+				"Location"
+			],
+			"displayName": {
+				"en": "Last Known Location"
+			},
+			"name": "lastKnownLocation",
+			"schema": "geopoint"
+		},
+		{
+			"@type": "Property",
+			"displayName": {
+				"en": "Configuration"
+			},
+			"name": "config",
+			"writable": true,
+			"schema": {
+				"@type": "Map",
+				"mapKey": {
+					"name": "param",
+					"schema": "string"
+				},
+				"mapValue": {
+					"name": "value",
+					"schema": "string"
+				}
+			}
+		},
+		{
+			"@type": "Property",
+			"displayName": {
+				"en": "Versions"
+			},
+			"name": "versions",
+			"writable": true,
+			"schema": {
+				"@type": "Map",
+				"mapKey": {
+					"name": "component",
+					"schema": "string"
+				},
+				"mapValue": {
+					"name": "version",
+					"schema": "string"
+				}
+			}
+		},
+		{
+			"@type": "Command",
+			"name": "reboot",
+			"displayName": {
+				"en": "Reboot"
+			},
+			"description": "Reboot the device"
+		},
+		{
+			"@type": "Command",
+			"name": "locate",
+			"displayName": {
+				"en": "Locate"
+			},
+			"description": "Locate the device"
+		},
+		{
+			"@type": "Command",
+			"name": "send",
+			"displayName": {
+				"en": "Send Command"
+			},
+			"description": "Send a command to the device",
+			"request": {
+				"name": "args",
+				"displayName": "Arguments",
+				"schema": "string"
+			},
+			"response": {
+				"name": "result",
+				"displayName": "Result",
+				"schema": "string"
+			}
+		}
+	]
+}

--- a/dtmi/tartabit/loraedgetracker-1.json
+++ b/dtmi/tartabit/loraedgetracker-1.json
@@ -1,0 +1,136 @@
+{
+  "@id": "dtmi:tartabit:LoRaEdgeTracker;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "LoRa Edge Tracker"
+  },
+  "@context": [
+    "dtmi:iotcentral:context;2",
+    "dtmi:dtdl:context;2"
+  ],
+  "contents": [
+    {
+      "@type": "Telemetry",
+      "displayName": {
+        "en": "Location"
+      },
+      "name": "location",
+      "schema": "geopoint"
+    },
+    {
+      "@type": [
+        "Telemetry",
+        "Current"
+      ],
+      "displayName": {
+        "en": "Charge"
+      },
+      "name": "charge",
+      "schema": "double",
+      "unit": "milliampere"
+    },
+    {
+      "@type": [
+        "Telemetry",
+        "Distance"
+      ],
+      "displayName": {
+        "en": "Location Fix Accuracy"
+      },
+      "name": "locFixAccuracy",
+      "schema": "double",
+      "unit": "metre"
+    },
+    {
+      "@type": [
+        "Telemetry",
+        "State"
+      ],
+      "displayName": {
+        "en": "Motion"
+      },
+      "name": "motion",
+      "schema": {
+        "@type": "Enum",
+        "enumValues": [
+          {
+            "displayName": {
+              "en": "Moving"
+            },
+            "enumValue": 1,
+            "name": "moving"
+          },
+          {
+            "displayName": {
+              "en": "Stationary"
+            },
+            "enumValue": 0,
+            "name": "stationary"
+          }
+        ],
+        "valueSchema": "integer"
+      }
+    },
+    {
+      "@type": [
+        "Telemetry",
+        "SoundPressure"
+      ],
+      "displayName": {
+        "en": "RSSI"
+      },
+      "name": "rssi",
+      "schema": "double",
+      "unit": "decibel"
+    },
+    {
+      "@type": "Telemetry",
+      "displayName": {
+        "en": "SNR"
+      },
+      "name": "snr",
+      "schema": "double"
+    },
+    {
+      "@type": [
+        "Telemetry",
+        "Temperature"
+      ],
+      "displayName": {
+        "en": "Temperature"
+      },
+      "name": "temperature",
+      "schema": "double",
+      "unit": "degreeCelsius"
+    },
+    {
+      "@type": [
+        "Telemetry",
+        "Voltage"
+      ],
+      "displayName": {
+        "en": "Voltage"
+      },
+      "name": "voltage",
+      "schema": "double",
+      "unit": "volt"
+    },
+    {
+      "@type": "Property",
+      "displayName": {
+        "en": "LNS"
+      },
+      "name": "lns",
+      "schema": "string",
+      "writable": false
+    },
+    {
+      "@type": "Telemetry",
+      "displayName": {
+        "en": "Location Fix Type"
+      },
+      "name": "locFixType",
+      "schema": "string"
+    }
+  ]
+}


### PR DESCRIPTION
### Thank you for contributing to the IoT Plug and Play Models repository

:memo: Please review this checklist before submission

- [ ] :eyes: The models submitted in this PR follow the [DTDL Naming Guidelines](https://github.com/Azure/iot-plugandplay-models-tools/wiki/DTDL-Naming-Guidelines) for contributing to this repository.
- [ ] 🕵️I have validated the models locally using the [dmr-client](https://github.com/Azure/iot-plugandplay-models-tools/tree/dev/clients/dotnet/Microsoft.IoT.ModelsRepository.CommandLine) command line tool.
- [ ] ❗ I understand once the PR is approved, the models are considered immutable: any edits will require to submit new files.
- [ ] ✨ When creating a new top level `dtmi:namespace`, I have completed the [PR Info Template](#pr-info-template) below.

:zap: PR validation steps are described in the tools [Wiki](https://github.com/Azure/iot-plugandplay-models-tools/wiki/Validation-Pipeline#pr-validation-checks).

## PR Info Template

When submitting models to the repository we ask that you provide as much of the following meta information around your models and related devices as possible. This info will be used to improve the _IoT Plug and Play_ ecosystem.

👇: Please replace the markdown comment examples with your own values.

### Company Info
Tartabit, LLC, www.tartabit.com github.com/tartabit

### IoT Plug and Play Device Info
These models are used by the Tartabit IoT Bridge to integrate various LPWA devices.

### Model Submission Goals
These models are used by the Tartabit IoT Bridge to integrate various LPWA devices.

### Code Owners & Reserved Names
Owned by Tartabit.

This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
