### PR TITLE
stm32 b_u585i_iot02a device template v3

### DIFF
--- a/dtmi/stmicroelectronics/b_u585i_iot02a/control_if-1.json
+++ b/dtmi/stmicroelectronics/b_u585i_iot02a/control_if-1.json
@@ -1,0 +1,97 @@
+{
+      "@context": [
+          "dtmi:iotcentral:context;2",
+          "dtmi:dtdl:context;2"
+      ],
+      "@id": "dtmi:stmicroelectronics:b_u585i_iot02a:control_if;1",
+      "@type": "Interface",
+      "contents": [
+          {
+              "@id": "dtmi:stmicroelectronics:b_u585i_iot02a:control_if:Pause;1",
+              "@type": "Command",
+              "commandType": "synchronous",
+              "description": {
+                  "en": "This Commands will put in pause the sensors transmission"
+              },
+              "displayName": {
+                  "en": "Pause"
+              },
+              "name": "Pause",
+              "response": {
+                  "@type": "CommandPayload",
+                  "name": "PauseResponse",
+                  "schema": {
+                      "@type": "Object",
+                      "displayName": {
+                          "en": "Object"
+                      },
+                      "fields": [
+                          {
+                              "name": "Result",
+                              "schema": "string"
+                          }
+                      ]
+                  }
+              }
+          },
+          {
+              "@id": "dtmi:stmicroelectronics:b_u585i_iot02a:control_if:Play;1",
+              "@type": "Command",
+              "commandType": "synchronous",
+              "description": {
+                  "en": "This Command will Resume the Sensors transmission"
+              },
+              "displayName": {
+                  "en": "Play"
+              },
+              "name": "Play",
+              "response": {
+                  "@type": "CommandPayload",
+                  "name": "PlayResponse",
+                  "schema": {
+                      "@type": "Object",
+                      "displayName": {
+                          "en": "Object"
+                      },
+                      "fields": [
+                          {
+                              "name": "Result",
+                              "schema": "string"
+                          }
+                      ]
+                  }
+              }
+          },
+          {
+              "@id": "dtmi:stmicroelectronics:b_u585i_iot02a:control_if:Reset;1",
+              "@type": "Command",
+              "commandType": "synchronous",
+              "description": {
+                  "en": "Reboot the board"
+              },
+              "displayName": {
+                  "en": "Reset"
+              },
+              "name": "Reset",
+              "response": {
+                  "@type": "CommandPayload",
+                  "name": "ResetResponse",
+                  "schema": {
+                      "@type": "Object",
+                      "displayName": {
+                          "en": "Object"
+                      },
+                      "fields": [
+                          {
+                              "name": "Result",
+                              "schema": "string"
+                          }
+                      ]
+                  }
+              }
+          }
+      ],
+      "displayName": {
+          "en": "Control interface for B-U585I-IOT02A"
+      }
+  }

--- a/dtmi/stmicroelectronics/b_u585i_iot02a/standard_fw-3.json
+++ b/dtmi/stmicroelectronics/b_u585i_iot02a/standard_fw-3.json
@@ -1,0 +1,39 @@
+{
+      "@id": "dtmi:stmicroelectronics:b_u585i_iot02a:standard_fw;3",
+      "@type": "Interface",
+      "contents": [
+          {
+              "@id": "dtmi:stmicroelectronics:b_u585i_iot02a:standard_fw:std_comp;2",
+              "@type": "Component",
+              "displayName": {
+                  "en": "Standard component"
+              },
+              "name": "std_comp",
+              "schema": "dtmi:stmicroelectronics:b_u585i_iot02a:standard_if;2"
+          },
+          {
+              "@id": "dtmi:stmicroelectronics:b_u585i_iot02a:standard_fw:ctrl_comp;2",
+              "@type": "Component",
+              "displayName": {
+                  "en": "Control component"
+              },
+              "name": "ctrl_comp",
+              "schema": "dtmi:stmicroelectronics:b_u585i_iot02a:control_if;1"
+          },
+          {
+              "@type": "Component",
+              "displayName": {
+                  "en": "Device info component"
+              },
+              "name": "deviceinfo",
+              "schema": "dtmi:azure:DeviceManagement:DeviceInformation;1"
+          }
+      ],
+      "displayName": {
+          "en": "B-U585I-IOT02A"
+      },
+      "@context": [
+          "dtmi:iotcentral:context;2",
+          "dtmi:dtdl:context;2"
+      ]
+  }

--- a/dtmi/stmicroelectronics/b_u585i_iot02a/standard_if-2.json
+++ b/dtmi/stmicroelectronics/b_u585i_iot02a/standard_if-2.json
@@ -1,0 +1,310 @@
+{
+      "@context": [
+          "dtmi:iotcentral:context;2",
+          "dtmi:dtdl:context;2"
+      ],
+      "@id": "dtmi:stmicroelectronics:b_u585i_iot02a:standard_if;2",
+      "@type": "Interface",
+      "contents": [
+          {
+              "@id": "dtmi:stmicroelectronics:b_u585i_iot02a:standard_if:control_LED;1",
+              "@type": "Property",
+              "description": {
+                  "en": "Led On/Off"
+              },
+              "displayName": {
+                  "en": "Control LED "
+              },
+              "name": "control_LED",
+              "schema": {
+                  "@id": "dtmi:stmicroelectronics:b_u585i_iot02a:standard_if:control_LED:schema;1",
+                  "@type": "Enum",
+                  "displayName": {
+                      "en": "Enum"
+                  },
+                  "enumValues": [
+                      {
+                          "@id": "dtmi:stmicroelectronics:b_u585i_iot02a:standard_if:control_LED:schema:off;1",
+                          "displayName": {
+                              "en": "off"
+                          },
+                          "enumValue": 0,
+                          "name": "off"
+                      },
+                      {
+                          "@id": "dtmi:stmicroelectronics:b_u585i_iot02a:standard_if:control_LED:schema:on;1",
+                          "displayName": {
+                              "en": "on"
+                          },
+                          "enumValue": 1,
+                          "name": "on"
+                      }
+                  ],
+                  "valueSchema": "integer"
+              },
+              "writable": true
+          },
+          {
+              "@id": "dtmi:stmicroelectronics:b_u585i_iot02a:standard_if:button_counter;1",
+              "@type": "Telemetry",
+              "description": {
+                  "en": "How many times the push button is pressed between two telemetries"
+              },
+              "displayName": {
+                  "en": "Button Counter"
+              },
+              "name": "button_counter",
+              "schema": "integer"
+          },
+          {
+              "@type": [
+                  "Telemetry",
+                  "Temperature"
+              ],
+              "description": {
+                  "en": "Temperature in degrees Celsius from HTS221 temperature sensor"
+              },
+              "displayName": {
+                  "en": "Temperature"
+              },
+              "name": "temperature",
+              "schema": "double",
+              "unit": "degreeCelsius"
+          },
+          {
+              "@type": [
+                  "Telemetry",
+                  "RelativeHumidity"
+              ],
+              "description": {
+                  "en": "relative humidity from HTS221 sensor"
+              },
+              "displayName": {
+                  "en": "Relative Humidity"
+              },
+              "name": "humidity",
+              "schema": "double",
+              "unit": "percent"
+          },
+          {
+              "@type": [
+                  "Telemetry",
+                  "Pressure"
+              ],
+              "description": {
+                  "en": "Pressure from LPS22HB sensor"
+              },
+              "displayName": {
+                  "en": "Pressure"
+              },
+              "name": "pressure",
+              "schema": "double",
+              "unit": "millibar"
+          },
+          {
+              "@type": "Telemetry",
+              "comment": "LSM6DSL Acceleration X/Y/Z components [mg]",
+              "displayName": {
+                  "en": "ISM330DHCX Acc Value [mg]"
+              },
+              "name": "acceleration",
+              "schema": {
+                  "@type": "Object",
+                  "description": {
+                      "en": "Single acceleration sample. I.e.: {a_x, a_y, a_z}."
+                  },
+                  "displayName": {
+                      "en": "Single acceleration sample."
+                  },
+                  "fields": [
+                      {
+                          "name": "a_x",
+                          "schema": "double"
+                      },
+                      {
+                          "name": "a_y",
+                          "schema": "double"
+                      },
+                      {
+                          "name": "a_z",
+                          "schema": "double"
+                      }
+                  ]
+              }
+          },
+          {
+              "@type": "Telemetry",
+              "comment": "LSM6DSL Gyroscope X/Y/Z components [mdps]",
+              "displayName": {
+                  "en": "ISM330DHCX Gyro Value [mdps]"
+              },
+              "name": "gyroscope",
+              "schema": {
+                  "@type": "Object",
+                  "description": {
+                      "en": "Single angular velocity sample. I.e.: {g_x, g_y, g_z}."
+                  },
+                  "displayName": {
+                      "en": "Single angular velocity sample."
+                  },
+                  "fields": [
+                      {
+                          "name": "g_x",
+                          "schema": "double"
+                      },
+                      {
+                          "name": "g_y",
+                          "schema": "double"
+                      },
+                      {
+                          "name": "g_z",
+                          "schema": "double"
+                      }
+                  ]
+              }
+          },
+          {
+              "@type": "Telemetry",
+              "comment": "LIS3MDL Magnetometer X/Y/Z components [mgauss]",
+              "displayName": {
+                  "en": "IIS2MDC Mag Value [mgauss]"
+              },
+              "name": "magnetometer",
+              "schema": {
+                  "@type": "Object",
+                  "description": {
+                      "en": "Single magnetic field sample. I.e.: {m_x, m_y, m_z}."
+                  },
+                  "displayName": {
+                      "en": "Single magnetic field sample."
+                  },
+                  "fields": [
+                      {
+                          "name": "m_x",
+                          "schema": "double"
+                      },
+                      {
+                          "name": "m_y",
+                          "schema": "double"
+                      },
+                      {
+                          "name": "m_z",
+                          "schema": "double"
+                      }
+                  ]
+              }
+          },
+          {
+              "@type": "Property",
+              "displayName": {
+                  "en": "Transmission period for telemetry data [in seconds]"
+              },
+              "name": "telemetry_interval",
+              "schema": "double",
+              "writable": true
+          },
+          {
+              "@type": "Property",
+              "description": {
+                  "en": "Accelerometer Full Scale"
+              },
+              "displayName": {
+                  "en": "Acc FS"
+              },
+              "name": "acc_fullscale",
+              "writable": true,
+              "schema": {
+                  "@type": "Enum",
+                  "enumValues": [
+                      {
+                          "displayName": {
+                              "en": "2G"
+                          },
+                          "enumValue": 2,
+                          "name": "G2"
+                      },
+                      {
+                          "displayName": {
+                              "en": "4G"
+                          },
+                          "enumValue": 4,
+                          "name": "G4"
+                      },
+                      {
+                          "displayName": {
+                              "en": "8G"
+                          },
+                          "enumValue": 8,
+                          "name": "G8"
+                      },
+                      {
+                          "displayName": {
+                              "en": "16G"
+                          },
+                          "enumValue": 16,
+                          "name": "G16"
+                      }
+                  ],
+                  "valueSchema": "integer"
+              }
+          },
+          {
+              "@type": "Property",
+              "description": {
+                  "en": "Gyroscope Full Scale"
+              },
+              "displayName": {
+                  "en": "Gyro FS"
+              },
+              "name": "gyro_fullscale",
+              "writable": true,
+              "schema": {
+                  "@type": "Enum",
+                  "enumValues": [
+                      {
+                          "displayName": {
+                              "en": "125dps"
+                          },
+                          "enumValue": 125,
+                          "name": "dps125"
+                      },
+                      {
+                          "displayName": {
+                              "en": "250dps"
+                          },
+                          "enumValue": 250,
+                          "name": "dps250"
+                      },
+                      {
+                          "displayName": {
+                              "en": "500dps"
+                          },
+                          "enumValue": 500,
+                          "name": "dps500"
+                      },
+                      {
+                          "displayName": {
+                              "en": "1000dps"
+                          },
+                          "enumValue": 1000,
+                          "name": "dps1000"
+                      },
+                      {
+                          "displayName": {
+                              "en": "2000dps"
+                          },
+                          "enumValue": 2000,
+                          "name": "dps2000"
+                      }
+                  ],
+                  "valueSchema": "integer"
+              }
+          }
+      ],
+      "description": {
+          "en": "Reports temperature, relative humidity, pressure, magnetometer, accelerometer and gyroscope."
+      },
+      "displayName": {
+          "en": "Standard interface for B-U585I-IOT02A"
+      }
+  }


### PR DESCRIPTION
### Thank you for contributing to the IoT Plug and Play Models repository

:memo: Please review this checklist before submission

- [x] :eyes: The models submitted in this PR follow the [DTDL Naming Guidelines](https://github.com/Azure/iot-plugandplay-models-tools/wiki/DTDL-Naming-Guidelines) for contributing to this repository.
- [x] 🕵️I have validated the models locally using the [dmr-client](https://github.com/Azure/iot-plugandplay-models-tools/tree/dev/clients/dotnet/Microsoft.IoT.ModelsRepository.CommandLine) command line tool.
- [x] ❗ I understand once the PR is approved, the models are considered immutable: any edits will require to submit new files.
- [x] ✨ When creating a new top level `dtmi:namespace`, I have completed the [PR Info Template](#pr-info-template) below.

:zap: PR validation steps are described in the tools [Wiki](https://github.com/Azure/iot-plugandplay-models-tools/wiki/Validation-Pipeline#pr-validation-checks).

## PR Info Template

When submitting models to the repository we ask that you provide as much of the following meta information around your models and related devices as possible. This info will be used to improve the _IoT Plug and Play_ ecosystem.

👇: Please replace the markdown comment examples with your own values.

### Company Info

> STMicroelectronics
<!--


Examples:
- Company name
- Company website
- GitHub presence
- Other

-->

### IoT Plug and Play Device Info
> STM32 B_U585I_IOT02A

<!--
Examples:
- Product website
- OS & Arch
- SDK used for model implementation
- Other

-->

### Model Submission Goals

> Using release X-CUBE-AZURE 2.0.0 [package ](https://www.st.com/en/embedded-software/x-cube-azure.html)
<!--

Examples:
- Device certification
- Presence in the [Certified Device catalog](https://devicecatalog.azure.com/)
- IoT Central integration
- Custom solution
- Other

-->

### Code Owners & Reserved Names

> Indicates GitHub alias entries to be added to the repo `CODEOWNERS` for the incoming model namespace. The codeowner is expected to be involved in subsequent DTDL model submissions against the same namespace.

<!--

If no alias is specified then we assume the PR submitter is responsible for the namespace.

Examples:
- @ContosoModelNamespaceOwner 1

-->

This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
