### PR TITLE
Add STMicroelectronics STM32H573I-DK model

### DIFF
--- a/dtmi/stmicroelectronics/stm32h573i_dk/control_if-1.json
+++ b/dtmi/stmicroelectronics/stm32h573i_dk/control_if-1.json
@@ -1,0 +1,97 @@
+{
+    "@context": [
+        "dtmi:iotcentral:context;2",
+        "dtmi:dtdl:context;2"
+    ],
+    "@id": "dtmi:stmicroelectronics:stm32h573i_dk:control_if;1",
+    "@type": "Interface",
+    "contents": [
+        {
+            "@id": "dtmi:stmicroelectronics:stm32h573i_dk:control_if:Pause;1",
+            "@type": "Command",
+            "commandType": "synchronous",
+            "description": {
+                "en": "This Commands will put in pause the sensors transmission"
+            },
+            "displayName": {
+                "en": "Pause"
+            },
+            "name": "Pause",
+            "response": {
+                "@type": "CommandPayload",
+                "name": "PauseResponse",
+                "schema": {
+                    "@type": "Object",
+                    "displayName": {
+                        "en": "Object"
+                    },
+                    "fields": [
+                        {
+                            "name": "Result",
+                            "schema": "string"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "@id": "dtmi:stmicroelectronics:stm32h573i_dk:control_if:Play;1",
+            "@type": "Command",
+            "commandType": "synchronous",
+            "description": {
+                "en": "This Command will Resume the Sensors transmission"
+            },
+            "displayName": {
+                "en": "Play"
+            },
+            "name": "Play",
+            "response": {
+                "@type": "CommandPayload",
+                "name": "PlayResponse",
+                "schema": {
+                    "@type": "Object",
+                    "displayName": {
+                        "en": "Object"
+                    },
+                    "fields": [
+                        {
+                            "name": "Result",
+                            "schema": "string"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "@id": "dtmi:stmicroelectronics:stm32h573i_dk:control_if:Reset;1",
+            "@type": "Command",
+            "commandType": "synchronous",
+            "description": {
+                "en": "Reboot the board"
+            },
+            "displayName": {
+                "en": "Reset"
+            },
+            "name": "Reset",
+            "response": {
+                "@type": "CommandPayload",
+                "name": "ResetResponse",
+                "schema": {
+                    "@type": "Object",
+                    "displayName": {
+                        "en": "Object"
+                    },
+                    "fields": [
+                        {
+                            "name": "Result",
+                            "schema": "string"
+                        }
+                    ]
+                }
+            }
+        }
+    ],
+    "displayName": {
+        "en": "Control interface for STM32H573I-DK"
+    }
+}

--- a/dtmi/stmicroelectronics/stm32h573i_dk/standard_fw-1.json
+++ b/dtmi/stmicroelectronics/stm32h573i_dk/standard_fw-1.json
@@ -1,0 +1,37 @@
+{
+    "@id": "dtmi:stmicroelectronics:stm32h573i_dk:standard_fw;1",
+    "@type": "Interface",
+    "displayName": "STM32H573I-DK Discovery Kit",
+    "@context": [
+      "dtmi:iotcentral:context;2",
+      "dtmi:dtdl:context;2"
+    ],
+    "contents": [
+      {
+          "@id": "dtmi:stmicroelectronics:stm32h573i_dk:standard_fw:std_comp;1",
+          "@type": "Component",
+          "displayName": {
+              "en": "Standard component"
+          },
+          "name": "std_comp",
+          "schema": "dtmi:stmicroelectronics:stm32h573i_dk:standard_if;1"
+      },
+      {
+          "@id": "dtmi:stmicroelectronics:stm32h573i_dk:standard_fw:ctrl_comp;1",
+          "@type": "Component",
+          "displayName": {
+              "en": "Control component"
+          },
+          "name": "ctrl_comp",
+          "schema": "dtmi:stmicroelectronics:stm32h573i_dk:control_if;1"
+      },
+      {
+          "@type": "Component",
+          "displayName": {
+              "en": "Device info component"
+          },
+          "name": "deviceinfo",
+          "schema": "dtmi:azure:DeviceManagement:DeviceInformation;1"
+      }
+    ]
+}

--- a/dtmi/stmicroelectronics/stm32h573i_dk/standard_if-1.json
+++ b/dtmi/stmicroelectronics/stm32h573i_dk/standard_if-1.json
@@ -1,0 +1,106 @@
+{
+    "@context": [
+      "dtmi:iotcentral:context;2",
+      "dtmi:dtdl:context;2"
+    ],
+    "@id": "dtmi:stmicroelectronics:stm32h573i_dk:standard_if;1",
+    "@type": "Interface",
+    "contents": [
+      {
+          "@id": "dtmi:stmicroelectronics:stm32h573i_dk:standard_if:control_LED;1",
+          "@type": [
+              "Property",
+              "Initialized"
+          ],
+          "description": {
+              "en": "Led On/Off"
+          },
+          "displayName": {
+              "en": "Control LED "
+          },
+          "name": "control_LED",
+          "schema": {
+              "@id": "dtmi:stmicroelectronics:stm32h573i_dk:standard_if:control_LED:schema;1",
+              "@type": "Enum",
+              "displayName": {
+                  "en": "Enum"
+              },
+              "enumValues": [
+                  {
+                      "@id": "dtmi:stmicroelectronics:stm32h573i_dk:standard_if:control_LED:schema:off;1",
+                      "displayName": {
+                          "en": "off"
+                      },
+                      "enumValue": 0,
+                      "name": "off"
+                  },
+                  {
+                      "@id": "dtmi:stmicroelectronics:stm32h573i_dk:standard_if:control_LED:schema:on;1",
+                      "displayName": {
+                          "en": "on"
+                      },
+                      "enumValue": 1,
+                      "name": "on"
+                  }
+              ],
+              "valueSchema": "integer"
+          },
+          "writable": true,
+          "initialValue": 0
+      },
+      {
+          "@id": "dtmi:stmicroelectronics:stm32h573i_dk:standard_if:button_counter;1",
+          "@type": [
+              "Telemetry",
+              "NumberValue"
+          ],
+          "description": {
+              "en": "How many times the push button is pressed between two telemetries"
+          },
+          "displayName": {
+              "en": "Button Counter"
+          },
+          "name": "button_counter",
+          "schema": "integer"
+      },
+      {
+          "@type": [
+              "Telemetry",
+              "NumberValue",
+              "Temperature"
+          ],
+          "description": {
+              "en": "Temperature in degrees Celsius from internal Digital Temperature Sensor"
+          },
+          "displayName": {
+              "en": "Temperature"
+          },
+          "name": "temperature",
+          "schema": "double",
+          "unit": "degreeCelsius"
+      },
+      {
+          "@type": [
+              "Property",
+              "NumberValue",
+              "Initialized"
+          ],
+          "displayName": {
+              "en": "Transmission period for telemetry data [in seconds]"
+          },
+          "name": "telemetry_interval",
+          "schema": "double",
+          "writable": true,
+          "decimalPlaces": 2,
+          "initialValue": 10,
+          "maxValue": 86400,
+          "minValue": 1
+      }
+    ],
+    "description": {
+      "en": "Reports data."
+    },
+    "displayName": {
+      "en": "Standard interface for STM32H573I-DK"
+    }
+}


### PR DESCRIPTION
### Thank you for contributing to the IoT Plug and Play Models repository

:memo: Please review this checklist before submission

- [X ] :eyes: The models submitted in this PR follow the [DTDL Naming Guidelines](https://github.com/Azure/iot-plugandplay-models-tools/wiki/DTDL-Naming-Guidelines) for contributing to this repository.
- [X ] 🕵️I have validated the models locally using the [dmr-client](https://github.com/Azure/iot-plugandplay-models-tools/tree/dev/clients/dotnet/Microsoft.IoT.ModelsRepository.CommandLine) command line tool.
- [X ] ❗ I understand once the PR is approved, the models are considered immutable: any edits will require to submit new files.
- [ ] ✨ When creating a new top level `dtmi:namespace`, I have completed the [PR Info Template](#pr-info-template) below.

:zap: PR validation steps are described in the tools [Wiki](https://github.com/Azure/iot-plugandplay-models-tools/wiki/Validation-Pipeline#pr-validation-checks).

## PR Info Template

When submitting models to the repository we ask that you provide as much of the following meta information around your models and related devices as possible. This info will be used to improve the _IoT Plug and Play_ ecosystem.

👇: Please replace the markdown comment examples with your own values.

### Company Info

> Info identifying your company (if applicable).

- Company name: STMicroelectronics
- Company website: https://www.st.com
- GitHub presence: https://github.com/STMicroelectronics


### IoT Plug and Play Device Info
> Info identifying your device.

- Product website:  https://www.st.com/en/evaluation-tools/stm32h573i-dk.html
- OS & Arch: Azure RTOS , ARM Cortex M33
- SDK used for model implementation: https://github.com/Azure/azure-sdk-for-c


### Model Submission Goals

> Info related to broader submission goals.  

- Device certification
- Presence in the [Certified Device catalog](https://devicecatalog.azure.com/)
- IoT Central integration


### Code Owners & Reserved Names

> Indicates GitHub alias entries to be added to the repo `CODEOWNERS` for the incoming model namespace. The codeowner is expected to be involved in subsequent DTDL model submissions against the same namespace.

GKNSTM

This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
